### PR TITLE
fix(schema): replace z.any() with proper diagram schemas, add runtime validation

### DIFF
--- a/src/content/case-studies.ts
+++ b/src/content/case-studies.ts
@@ -1,4 +1,4 @@
-import type { CaseStudy } from "@/lib/content-schema";
+import { validateCaseStudies, type CaseStudy } from "@/lib/content-schema";
 
 export const caseStudies: CaseStudy[] = [
   {
@@ -370,4 +370,8 @@ export function getAdjacentCaseStudies(slug: string): {
     previous: caseStudies[index - 1] ?? null,
     next: caseStudies[index + 1] ?? null,
   };
+}
+
+if (process.env.NODE_ENV !== "production") {
+  validateCaseStudies(caseStudies);
 }

--- a/src/lib/content-schema.ts
+++ b/src/lib/content-schema.ts
@@ -32,6 +32,34 @@ export const disclosureMatrixSchema = z.object({
   proofLinks: z.array(z.url()),
 });
 
+const diagramNodeSchema = z
+  .object({
+    id: z.string(),
+    type: z.string().optional(),
+    position: z.object({
+      x: z.number(),
+      y: z.number(),
+    }),
+    data: z
+      .object({
+        label: z.string(),
+      })
+      .passthrough(),
+  })
+  .passthrough();
+
+const diagramEdgeSchema = z
+  .object({
+    id: z.string(),
+    source: z.string(),
+    target: z.string(),
+    type: z.string().optional(),
+    animated: z.boolean().optional(),
+    label: z.string().optional(),
+    style: z.record(z.string(), z.unknown()).optional(),
+  })
+  .passthrough();
+
 export const caseStudySchema = z.object({
   slug: z.enum(["form-factor", "orwell-scraper", "palo-alto", "portus"]),
   title: z.string().min(1),
@@ -61,6 +89,8 @@ export const caseStudySchema = z.object({
         alt: z.string().optional(),
         content: z.string().optional(),
         caption: z.string().optional(),
+        diagramNodes: z.array(diagramNodeSchema).optional(),
+        diagramEdges: z.array(diagramEdgeSchema).optional(),
       })
     )
     .optional(),


### PR DESCRIPTION
## Summary
- Replace `z.array(z.any())` for `diagramNodes` and `diagramEdges` with proper Zod schemas validating id, position, data, source, target, etc. with `.passthrough()` for @xyflow compatibility
- Add development-only `validateCaseStudies()` call at module load time in `case-studies.ts`

## Verification
- [x] TypeScript check passes
- [x] All 37 unit tests pass (including content-schema tests)
- [x] Production build succeeds
- [x] No file overlap with other PRs

Closes #14, Closes #15