### PR TITLE
test: add unit tests for terminal.ts and github.ts

### DIFF
--- a/src/test/github.test.ts
+++ b/src/test/github.test.ts
@@ -1,0 +1,134 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "../../node_modules/vitest/dist/index.js";
+import { fetchGitHubPulse } from "@/lib/github";
+
+function createPushEvent(overrides?: {
+  created_at?: string;
+  commits?: { sha: string }[];
+  size?: number;
+}) {
+  return {
+    type: "PushEvent",
+    created_at: overrides?.created_at ?? "2026-04-01T12:00:00Z",
+    payload: {
+      commits: overrides?.commits,
+      size: overrides?.size,
+    },
+  };
+}
+
+describe("fetchGitHubPulse", () => {
+  const fetchMock = vi.fn<typeof fetch>();
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock.mockReset();
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("returns pulse data for a successful fetch with push events", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          createPushEvent({ created_at: "2026-04-02T12:00:00Z", commits: [{ sha: "a" }, { sha: "b" }] }),
+          { type: "WatchEvent", created_at: "2026-04-01T12:00:00Z", payload: {} },
+        ]),
+        { status: 200 }
+      )
+    );
+
+    await expect(fetchGitHubPulse("slenthekid")).resolves.toEqual({
+      events: [{ date: "2026-04-02", commits: 2 }],
+      lastActive: "2026-04-02",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.github.com/users/slenthekid/events/public?per_page=100&page=1",
+      {
+        headers: { Accept: "application/vnd.github.v3+json" },
+        next: { revalidate: 3600 },
+      }
+    );
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns null for a non-200 response", async () => {
+    fetchMock.mockResolvedValue(new Response(JSON.stringify({ message: "rate limited" }), { status: 403 }));
+
+    await expect(fetchGitHubPulse("slenthekid")).resolves.toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns null when the API returns an empty events array", async () => {
+    fetchMock.mockResolvedValue(new Response(JSON.stringify([]), { status: 200 }));
+
+    await expect(fetchGitHubPulse("slenthekid")).resolves.toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns null when fetch throws a network error", async () => {
+    fetchMock.mockRejectedValue(new Error("network down"));
+
+    await expect(fetchGitHubPulse("slenthekid")).resolves.toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("fetches a second page when the first page has 100 events", async () => {
+    const firstPage = Array.from({ length: 100 }, (_, index) =>
+      createPushEvent({
+        created_at: `2026-04-${String((index % 9) + 1).padStart(2, "0")}T12:00:00Z`,
+        commits: [{ sha: `sha-${index}` }],
+      })
+    );
+    const secondPage = [createPushEvent({ created_at: "2026-03-20T12:00:00Z", commits: [{ sha: "later" }] })];
+
+    fetchMock
+      .mockResolvedValueOnce(new Response(JSON.stringify(firstPage), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(secondPage), { status: 200 }));
+
+    const result = await fetchGitHubPulse("slenthekid");
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[1]?.[0]).toBe(
+      "https://api.github.com/users/slenthekid/events/public?per_page=100&page=2"
+    );
+    expect(result).not.toBeNull();
+    expect(result?.events).toHaveLength(101);
+  });
+
+  it("uses payload.commits length and falls back to payload.size", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          createPushEvent({ created_at: "2026-04-02T12:00:00Z", commits: [{ sha: "a" }, { sha: "b" }, { sha: "c" }], size: 9 }),
+          createPushEvent({ created_at: "2026-04-01T12:00:00Z", size: 4 }),
+        ]),
+        { status: 200 }
+      )
+    );
+
+    await expect(fetchGitHubPulse("slenthekid")).resolves.toEqual({
+      events: [
+        { date: "2026-04-02", commits: 3 },
+        { date: "2026-04-01", commits: 4 },
+      ],
+      lastActive: "2026-04-02",
+    });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/test/terminal.test.ts
+++ b/src/test/terminal.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "../../node_modules/vitest/dist/index.js";
+import { easterEggs, terminalHelp, terminalConfig, virtualFs } from "@/content/system";
+import {
+  createInitialState,
+  executeCommand,
+  type TerminalLine,
+  type TerminalState,
+} from "@/lib/terminal";
+
+function getNonInputLines(state: TerminalState): TerminalLine[] {
+  return state.output.filter((line) => line.type !== "input");
+}
+
+function getLastNonInputLine(state: TerminalState): TerminalLine | undefined {
+  return getNonInputLines(state).at(-1);
+}
+
+describe("executeCommand", () => {
+  it("returns help output with the expected commands", () => {
+    const result = executeCommand(createInitialState(), "help");
+    const lines = getNonInputLines(result.state);
+
+    expect(lines).toHaveLength(Object.keys(terminalHelp).length);
+    expect(lines.map((line) => line.text)).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("help"),
+        expect.stringContaining("ls"),
+        expect.stringContaining("cd"),
+        expect.stringContaining("cat"),
+        expect.stringContaining("echo"),
+      ])
+    );
+  });
+
+  it("lists the root directory from home", () => {
+    const result = executeCommand(createInitialState(), "ls");
+    const line = getLastNonInputLine(result.state);
+
+    expect(line).toEqual({ text: "about  work/  resume", type: "output" });
+  });
+
+  it("changes cwd when cd points to a valid directory", () => {
+    const result = executeCommand(createInitialState(), "cd work");
+
+    expect(result.state.cwd).toBe("work");
+    expect(result.navigate).toBe("/work");
+    expect(result.state.history).toEqual(["cd work"]);
+  });
+
+  it("returns an error when cd points to an invalid directory", () => {
+    const result = executeCommand(createInitialState(), "cd missing-dir");
+
+    expect(result.state.cwd).toBe("~");
+    expect(getLastNonInputLine(result.state)).toEqual({
+      text: "cd: no such file or directory: missing-dir",
+      type: "error",
+    });
+  });
+
+  it("returns to home when cd has no arguments", () => {
+    const state: TerminalState = {
+      ...createInitialState(),
+      cwd: "work",
+    };
+
+    const result = executeCommand(state, "cd");
+
+    expect(result.state.cwd).toBe("~");
+    expect(getNonInputLines(result.state)).toEqual([]);
+  });
+
+  it("returns file contents for cat on a valid file", () => {
+    const result = executeCommand(createInitialState(), "cat about");
+
+    expect(getLastNonInputLine(result.state)).toEqual({
+      text: virtualFs.about,
+      type: "output",
+    });
+  });
+
+  it("returns an error for cat on a missing file", () => {
+    const result = executeCommand(createInitialState(), "cat missing-file");
+
+    expect(getLastNonInputLine(result.state)).toEqual({
+      text: "cat: missing-file: No such file or directory",
+      type: "error",
+    });
+  });
+
+  it("returns an error for cat on a directory", () => {
+    const result = executeCommand(createInitialState(), "cat work");
+
+    expect(getLastNonInputLine(result.state)).toEqual({
+      text: "cat: work: Is a directory",
+      type: "error",
+    });
+  });
+
+  it("echoes argument text", () => {
+    const result = executeCommand(createInitialState(), "echo hello terminal");
+
+    expect(getLastNonInputLine(result.state)).toEqual({
+      text: "hello terminal",
+      type: "output",
+    });
+  });
+
+  it("echo with no arguments returns an empty output line", () => {
+    const result = executeCommand(createInitialState(), "echo");
+
+    expect(getLastNonInputLine(result.state)).toEqual({ text: "", type: "output" });
+  });
+
+  it("history includes the current command when prior history is empty", () => {
+    const result = executeCommand(createInitialState(), "history");
+
+    expect(getNonInputLines(result.state)).toEqual([{ text: "1  history", type: "system" }]);
+  });
+
+  it("clear removes prior terminal output", () => {
+    const populated = executeCommand(createInitialState(), "help").state;
+    const cleared = executeCommand(populated, "clear");
+
+    expect(populated.output.length).toBeGreaterThan(0);
+    expect(cleared.state.output).toEqual([]);
+  });
+
+  it("returns the expected whoami output", () => {
+    const result = executeCommand(createInitialState(), "whoami");
+
+    expect(getLastNonInputLine(result.state)).toEqual({
+      text: "visitor -- browsing slen.win from [no tracking, we respect privacy]",
+      type: "output",
+    });
+  });
+
+  it("prints the current working directory", () => {
+    const state: TerminalState = {
+      ...createInitialState(),
+      cwd: "work",
+    };
+
+    const result = executeCommand(state, "pwd");
+
+    expect(getLastNonInputLine(result.state)).toEqual({ text: "work", type: "output" });
+  });
+
+  it("returns a command-not-found error for unknown commands", () => {
+    const result = executeCommand(createInitialState(), "foobar");
+
+    expect(getLastNonInputLine(result.state)).toEqual({
+      text: "command not found: foobar. Type 'help' for available commands.",
+      type: "error",
+    });
+  });
+
+  it("handles empty input without changing state", () => {
+    const state = createInitialState();
+    const result = executeCommand(state, "   ");
+
+    expect(result.state).toBe(state);
+    expect(result.navigate).toBeUndefined();
+    expect(result.state.output).toEqual([]);
+    expect(result.state.history).toEqual([]);
+  });
+
+  it.each<[string, string]>([
+    ["sudo", easterEggs.sudo[0]],
+    ["vim", easterEggs.vim[0]],
+    ["coffee", easterEggs.coffee[0]],
+    ["matrix", easterEggs.matrix[0]],
+  ])("returns easter egg output for %s", (command: string, expected: string) => {
+    const result = executeCommand(createInitialState(), command);
+
+    expect(getLastNonInputLine(result.state)).toEqual({ text: expected, type: "system" });
+  });
+
+  it("prefixes input lines with the configured prompt", () => {
+    const result = executeCommand(createInitialState(), "echo hi");
+
+    expect(result.state.output[0]).toEqual({
+      text: `${terminalConfig.prompt}echo hi`,
+      type: "input",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- **terminal.test.ts** (186 lines): 15+ test cases covering all executeCommand branches — help, ls, cd, cat, echo, pwd, whoami, history, clear, unknown commands, empty input, and easter eggs (sudo, vim, coffee, matrix)
- **github.test.ts** (134 lines): 6+ test cases for fetchGitHubPulse — successful fetch with events, 4xx errors returning null, empty events, network errors, pagination, and commit count calculation

## Verification
- [x] TypeScript check passes
- [x] All 64 unit tests pass (37 existing + 27 new)
- [x] Production build succeeds
- [x] No file overlap with other PRs

Closes #13, Closes #23