### PR TITLE
test: add unit tests for hooks and shell components

### DIFF
--- a/src/test/hooks.test.ts
+++ b/src/test/hooks.test.ts
@@ -1,0 +1,69 @@
+import { renderHook, act } from "@testing-library/react";
+import { createElement } from "react";
+import { renderToString } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
+import { useSessionFlag } from "@/hooks/useSessionFlag";
+
+describe("usePrefersReducedMotion", () => {
+  it("returns false by default", () => {
+    const { result } = renderHook(() => usePrefersReducedMotion());
+
+    expect(result.current).toBe(false);
+  });
+
+  it("returns the server snapshot during SSR", () => {
+    function TestComponent() {
+      const prefersReducedMotion = usePrefersReducedMotion();
+      return createElement("span", null, String(prefersReducedMotion));
+    }
+
+    expect(renderToString(createElement(TestComponent))).toContain("false");
+  });
+});
+
+describe("useSessionFlag", () => {
+  it("returns false and a setter when the key is not set", () => {
+    const { result } = renderHook(() => useSessionFlag("missing-flag"));
+
+    expect(result.current[0]).toBe(false);
+    expect(result.current[1]).toBeTypeOf("function");
+  });
+
+  it("updates sessionStorage and returns true after setting the flag", () => {
+    const { result } = renderHook(() => useSessionFlag("visit-flag"));
+
+    act(() => {
+      result.current[1]();
+    });
+
+    expect(sessionStorage.getItem("visit-flag")).toBe("1");
+    expect(result.current[0]).toBe(true);
+  });
+
+  it("keeps multiple hook keys independent", () => {
+    const first = renderHook(() => useSessionFlag("first-flag"));
+    const second = renderHook(() => useSessionFlag("second-flag"));
+
+    act(() => {
+      first.result.current[1]();
+    });
+
+    expect(first.result.current[0]).toBe(true);
+    expect(second.result.current[0]).toBe(false);
+    expect(sessionStorage.getItem("first-flag")).toBe("1");
+    expect(sessionStorage.getItem("second-flag")).toBeNull();
+  });
+
+  it("handles sessionStorage read errors gracefully", () => {
+    const getItemSpy = vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("sessionStorage unavailable");
+    });
+
+    const { result } = renderHook(() => useSessionFlag("error-flag"));
+
+    expect(result.current[0]).toBe(false);
+
+    getItemSpy.mockRestore();
+  });
+});

--- a/src/test/shell-components.test.tsx
+++ b/src/test/shell-components.test.tsx
@@ -1,0 +1,148 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { BootSequence } from "@/components/shell/BootSequence";
+import { CursorTrail } from "@/components/shell/CursorTrail";
+import { MatrixRain } from "@/components/shell/MatrixRain";
+import { HitMarker } from "@/components/shell/HitMarker";
+
+interface MatchMediaOptions {
+  reducedMotion?: boolean;
+  pointerFine?: boolean;
+}
+
+function setMatchMedia({ reducedMotion = false, pointerFine = true }: MatchMediaOptions = {}) {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches:
+        query === "(prefers-reduced-motion: reduce)"
+          ? reducedMotion
+          : query === "(pointer: fine)"
+            ? pointerFine
+            : false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    })),
+  });
+}
+
+function installCanvasMocks() {
+  const context = {
+    scale: vi.fn(),
+    clearRect: vi.fn(),
+    beginPath: vi.fn(),
+    arc: vi.fn(),
+    fill: vi.fn(),
+    fillRect: vi.fn(),
+    fillText: vi.fn(),
+    shadowBlur: 0,
+    shadowColor: "transparent",
+    fillStyle: "#000",
+    font: "",
+  };
+
+  Object.defineProperty(HTMLCanvasElement.prototype, "getContext", {
+    configurable: true,
+    value: vi.fn(() => context),
+  });
+}
+
+class MockAudio {
+  volume = 1;
+
+  cloneNode() {
+    return new MockAudio();
+  }
+
+  play() {
+    return Promise.resolve();
+  }
+}
+
+beforeEach(() => {
+  installCanvasMocks();
+  setMatchMedia();
+  vi.stubGlobal("requestAnimationFrame", vi.fn(() => 1));
+  vi.stubGlobal("cancelAnimationFrame", vi.fn());
+  vi.stubGlobal("Audio", MockAudio);
+});
+
+describe("BootSequence", () => {
+  it("renders on first visit when the session flag is not set", () => {
+    render(<BootSequence />);
+
+    expect(screen.getByTestId("boot-sequence")).toBeInTheDocument();
+  });
+
+  it("does not render when the session flag is already set", () => {
+    sessionStorage.setItem("boot-seen", "1");
+
+    render(<BootSequence />);
+
+    expect(screen.queryByTestId("boot-sequence")).not.toBeInTheDocument();
+  });
+
+  it("skips the animation when reduced motion is preferred", async () => {
+    setMatchMedia({ reducedMotion: true });
+
+    render(<BootSequence />);
+
+    expect(screen.queryByTestId("boot-sequence")).not.toBeInTheDocument();
+    await waitFor(() => expect(sessionStorage.getItem("boot-seen")).toBe("1"));
+  });
+});
+
+describe("CursorTrail", () => {
+  it("returns null when reduced motion is preferred", () => {
+    setMatchMedia({ reducedMotion: true });
+    const { container } = render(<CursorTrail />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("returns null on non-desktop pointers", () => {
+    setMatchMedia({ pointerFine: false });
+    const { container } = render(<CursorTrail />);
+
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+describe("MatrixRain", () => {
+  it("renders a canvas element", () => {
+    const { container } = render(<MatrixRain />);
+
+    expect(container.querySelector("canvas.matrix-rain")).toBeInTheDocument();
+  });
+
+  it("skips animation work when reduced motion is preferred", () => {
+    setMatchMedia({ reducedMotion: true });
+    const requestAnimationFrameSpy = vi.fn(() => 1);
+    vi.stubGlobal("requestAnimationFrame", requestAnimationFrameSpy);
+
+    const { container } = render(<MatrixRain />);
+
+    expect(container.querySelector("canvas.matrix-rain")).toBeInTheDocument();
+    expect(requestAnimationFrameSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("HitMarker", () => {
+  it("returns null when reduced motion is preferred", () => {
+    setMatchMedia({ reducedMotion: true });
+    const { container } = render(<HitMarker />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing initially before any clicks occur", () => {
+    const { container } = render(<HitMarker />);
+
+    expect(container.querySelector("svg")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- **hooks.test.ts** (69 lines): Tests for `usePrefersReducedMotion` (default value, SSR snapshot) and `useSessionFlag` (per-key isolation, setFlag behavior, sessionStorage error handling)
- **shell-components.test.tsx** (148 lines): Tests for `BootSequence` (first visit render, session flag skip, reduced motion), `CursorTrail` (null on reduced motion, null on non-desktop), `MatrixRain` (canvas render, reduced motion), `HitMarker` (null on reduced motion)

## Verification
- [x] TypeScript check passes
- [x] All 52 unit tests pass (37 existing + 15 new)
- [x] Production build succeeds
- [x] No file overlap with other PRs

Closes #27, Closes #28