### PR TITLE
test: add unit tests for terminal, github, hooks, and shell components

### DIFF
--- a/src/test/github.test.ts
+++ b/src/test/github.test.ts
@@ -1,0 +1,134 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "../../node_modules/vitest/dist/index.js";
+import { fetchGitHubPulse } from "@/lib/github";
+
+function createPushEvent(overrides?: {
+  created_at?: string;
+  commits?: { sha: string }[];
+  size?: number;
+}) {
+  return {
+    type: "PushEvent",
+    created_at: overrides?.created_at ?? "2026-04-01T12:00:00Z",
+    payload: {
+      commits: overrides?.commits,
+      size: overrides?.size,
+    },
+  };
+}
+
+describe("fetchGitHubPulse", () => {
+  const fetchMock = vi.fn<typeof fetch>();
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchMock);
+    fetchMock.mockReset();
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("returns pulse data for a successful fetch with push events", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          createPushEvent({ created_at: "2026-04-02T12:00:00Z", commits: [{ sha: "a" }, { sha: "b" }] }),
+          { type: "WatchEvent", created_at: "2026-04-01T12:00:00Z", payload: {} },
+        ]),
+        { status: 200 }
+      )
+    );
+
+    await expect(fetchGitHubPulse("slenthekid")).resolves.toEqual({
+      events: [{ date: "2026-04-02", commits: 2 }],
+      lastActive: "2026-04-02",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.github.com/users/slenthekid/events/public?per_page=100&page=1",
+      {
+        headers: { Accept: "application/vnd.github.v3+json" },
+        next: { revalidate: 3600 },
+      }
+    );
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns null for a non-200 response", async () => {
+    fetchMock.mockResolvedValue(new Response(JSON.stringify({ message: "rate limited" }), { status: 403 }));
+
+    await expect(fetchGitHubPulse("slenthekid")).resolves.toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns null when the API returns an empty events array", async () => {
+    fetchMock.mockResolvedValue(new Response(JSON.stringify([]), { status: 200 }));
+
+    await expect(fetchGitHubPulse("slenthekid")).resolves.toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns null when fetch throws a network error", async () => {
+    fetchMock.mockRejectedValue(new Error("network down"));
+
+    await expect(fetchGitHubPulse("slenthekid")).resolves.toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("fetches a second page when the first page has 100 events", async () => {
+    const firstPage = Array.from({ length: 100 }, (_, index) =>
+      createPushEvent({
+        created_at: `2026-04-${String((index % 9) + 1).padStart(2, "0")}T12:00:00Z`,
+        commits: [{ sha: `sha-${index}` }],
+      })
+    );
+    const secondPage = [createPushEvent({ created_at: "2026-03-20T12:00:00Z", commits: [{ sha: "later" }] })];
+
+    fetchMock
+      .mockResolvedValueOnce(new Response(JSON.stringify(firstPage), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(secondPage), { status: 200 }));
+
+    const result = await fetchGitHubPulse("slenthekid");
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[1]?.[0]).toBe(
+      "https://api.github.com/users/slenthekid/events/public?per_page=100&page=2"
+    );
+    expect(result).not.toBeNull();
+    expect(result?.events).toHaveLength(101);
+  });
+
+  it("uses payload.commits length and falls back to payload.size", async () => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          createPushEvent({ created_at: "2026-04-02T12:00:00Z", commits: [{ sha: "a" }, { sha: "b" }, { sha: "c" }], size: 9 }),
+          createPushEvent({ created_at: "2026-04-01T12:00:00Z", size: 4 }),
+        ]),
+        { status: 200 }
+      )
+    );
+
+    await expect(fetchGitHubPulse("slenthekid")).resolves.toEqual({
+      events: [
+        { date: "2026-04-02", commits: 3 },
+        { date: "2026-04-01", commits: 4 },
+      ],
+      lastActive: "2026-04-02",
+    });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/test/hooks.test.ts
+++ b/src/test/hooks.test.ts
@@ -1,0 +1,69 @@
+import { renderHook, act } from "@testing-library/react";
+import { createElement } from "react";
+import { renderToString } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
+import { useSessionFlag } from "@/hooks/useSessionFlag";
+
+describe("usePrefersReducedMotion", () => {
+  it("returns false by default", () => {
+    const { result } = renderHook(() => usePrefersReducedMotion());
+
+    expect(result.current).toBe(false);
+  });
+
+  it("returns the server snapshot during SSR", () => {
+    function TestComponent() {
+      const prefersReducedMotion = usePrefersReducedMotion();
+      return createElement("span", null, String(prefersReducedMotion));
+    }
+
+    expect(renderToString(createElement(TestComponent))).toContain("false");
+  });
+});
+
+describe("useSessionFlag", () => {
+  it("returns false and a setter when the key is not set", () => {
+    const { result } = renderHook(() => useSessionFlag("missing-flag"));
+
+    expect(result.current[0]).toBe(false);
+    expect(result.current[1]).toBeTypeOf("function");
+  });
+
+  it("updates sessionStorage and returns true after setting the flag", () => {
+    const { result } = renderHook(() => useSessionFlag("visit-flag"));
+
+    act(() => {
+      result.current[1]();
+    });
+
+    expect(sessionStorage.getItem("visit-flag")).toBe("1");
+    expect(result.current[0]).toBe(true);
+  });
+
+  it("keeps multiple hook keys independent", () => {
+    const first = renderHook(() => useSessionFlag("first-flag"));
+    const second = renderHook(() => useSessionFlag("second-flag"));
+
+    act(() => {
+      first.result.current[1]();
+    });
+
+    expect(first.result.current[0]).toBe(true);
+    expect(second.result.current[0]).toBe(false);
+    expect(sessionStorage.getItem("first-flag")).toBe("1");
+    expect(sessionStorage.getItem("second-flag")).toBeNull();
+  });
+
+  it("handles sessionStorage read errors gracefully", () => {
+    const getItemSpy = vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("sessionStorage unavailable");
+    });
+
+    const { result } = renderHook(() => useSessionFlag("error-flag"));
+
+    expect(result.current[0]).toBe(false);
+
+    getItemSpy.mockRestore();
+  });
+});

--- a/src/test/shell-components.test.tsx
+++ b/src/test/shell-components.test.tsx
@@ -1,0 +1,148 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { BootSequence } from "@/components/shell/BootSequence";
+import { CursorTrail } from "@/components/shell/CursorTrail";
+import { MatrixRain } from "@/components/shell/MatrixRain";
+import { HitMarker } from "@/components/shell/HitMarker";
+
+interface MatchMediaOptions {
+  reducedMotion?: boolean;
+  pointerFine?: boolean;
+}
+
+function setMatchMedia({ reducedMotion = false, pointerFine = true }: MatchMediaOptions = {}) {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches:
+        query === "(prefers-reduced-motion: reduce)"
+          ? reducedMotion
+          : query === "(pointer: fine)"
+            ? pointerFine
+            : false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    })),
+  });
+}
+
+function installCanvasMocks() {
+  const context = {
+    scale: vi.fn(),
+    clearRect: vi.fn(),
+    beginPath: vi.fn(),
+    arc: vi.fn(),
+    fill: vi.fn(),
+    fillRect: vi.fn(),
+    fillText: vi.fn(),
+    shadowBlur: 0,
+    shadowColor: "transparent",
+    fillStyle: "#000",
+    font: "",
+  };
+
+  Object.defineProperty(HTMLCanvasElement.prototype, "getContext", {
+    configurable: true,
+    value: vi.fn(() => context),
+  });
+}
+
+class MockAudio {
+  volume = 1;
+
+  cloneNode() {
+    return new MockAudio();
+  }
+
+  play() {
+    return Promise.resolve();
+  }
+}
+
+beforeEach(() => {
+  installCanvasMocks();
+  setMatchMedia();
+  vi.stubGlobal("requestAnimationFrame", vi.fn(() => 1));
+  vi.stubGlobal("cancelAnimationFrame", vi.fn());
+  vi.stubGlobal("Audio", MockAudio);
+});
+
+describe("BootSequence", () => {
+  it("renders on first visit when the session flag is not set", () => {
+    render(<BootSequence />);
+
+    expect(screen.getByTestId("boot-sequence")).toBeInTheDocument();
+  });
+
+  it("does not render when the session flag is already set", () => {
+    sessionStorage.setItem("boot-seen", "1");
+
+    render(<BootSequence />);
+
+    expect(screen.queryByTestId("boot-sequence")).not.toBeInTheDocument();
+  });
+
+  it("skips the animation when reduced motion is preferred", async () => {
+    setMatchMedia({ reducedMotion: true });
+
+    render(<BootSequence />);
+
+    expect(screen.queryByTestId("boot-sequence")).not.toBeInTheDocument();
+    await waitFor(() => expect(sessionStorage.getItem("boot-seen")).toBe("1"));
+  });
+});
+
+describe("CursorTrail", () => {
+  it("returns null when reduced motion is preferred", () => {
+    setMatchMedia({ reducedMotion: true });
+    const { container } = render(<CursorTrail />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("returns null on non-desktop pointers", () => {
+    setMatchMedia({ pointerFine: false });
+    const { container } = render(<CursorTrail />);
+
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+describe("MatrixRain", () => {
+  it("renders a canvas element", () => {
+    const { container } = render(<MatrixRain />);
+
+    expect(container.querySelector("canvas.matrix-rain")).toBeInTheDocument();
+  });
+
+  it("skips animation work when reduced motion is preferred", () => {
+    setMatchMedia({ reducedMotion: true });
+    const requestAnimationFrameSpy = vi.fn(() => 1);
+    vi.stubGlobal("requestAnimationFrame", requestAnimationFrameSpy);
+
+    const { container } = render(<MatrixRain />);
+
+    expect(container.querySelector("canvas.matrix-rain")).toBeInTheDocument();
+    expect(requestAnimationFrameSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("HitMarker", () => {
+  it("returns null when reduced motion is preferred", () => {
+    setMatchMedia({ reducedMotion: true });
+    const { container } = render(<HitMarker />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing initially before any clicks occur", () => {
+    const { container } = render(<HitMarker />);
+
+    expect(container.querySelector("svg")).toBeNull();
+  });
+});

--- a/src/test/terminal.test.ts
+++ b/src/test/terminal.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "../../node_modules/vitest/dist/index.js";
+import { easterEggs, terminalHelp, terminalConfig, virtualFs } from "@/content/system";
+import {
+  createInitialState,
+  executeCommand,
+  type TerminalLine,
+  type TerminalState,
+} from "@/lib/terminal";
+
+function getNonInputLines(state: TerminalState): TerminalLine[] {
+  return state.output.filter((line) => line.type !== "input");
+}
+
+function getLastNonInputLine(state: TerminalState): TerminalLine | undefined {
+  return getNonInputLines(state).at(-1);
+}
+
+describe("executeCommand", () => {
+  it("returns help output with the expected commands", () => {
+    const result = executeCommand(createInitialState(), "help");
+    const lines = getNonInputLines(result.state);
+
+    expect(lines).toHaveLength(Object.keys(terminalHelp).length);
+    expect(lines.map((line) => line.text)).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("help"),
+        expect.stringContaining("ls"),
+        expect.stringContaining("cd"),
+        expect.stringContaining("cat"),
+        expect.stringContaining("echo"),
+      ])
+    );
+  });
+
+  it("lists the root directory from home", () => {
+    const result = executeCommand(createInitialState(), "ls");
+    const line = getLastNonInputLine(result.state);
+
+    expect(line).toEqual({ text: "about  work/  resume", type: "output" });
+  });
+
+  it("changes cwd when cd points to a valid directory", () => {
+    const result = executeCommand(createInitialState(), "cd work");
+
+    expect(result.state.cwd).toBe("work");
+    expect(result.navigate).toBe("/work");
+    expect(result.state.history).toEqual(["cd work"]);
+  });
+
+  it("returns an error when cd points to an invalid directory", () => {
+    const result = executeCommand(createInitialState(), "cd missing-dir");
+
+    expect(result.state.cwd).toBe("~");
+    expect(getLastNonInputLine(result.state)).toEqual({
+      text: "cd: no such file or directory: missing-dir",
+      type: "error",
+    });
+  });
+
+  it("returns to home when cd has no arguments", () => {
+    const state: TerminalState = {
+      ...createInitialState(),
+      cwd: "work",
+    };
+
+    const result = executeCommand(state, "cd");
+
+    expect(result.state.cwd).toBe("~");
+    expect(getNonInputLines(result.state)).toEqual([]);
+  });
+
+  it("returns file contents for cat on a valid file", () => {
+    const result = executeCommand(createInitialState(), "cat about");
+
+    expect(getLastNonInputLine(result.state)).toEqual({
+      text: virtualFs.about,
+      type: "output",
+    });
+  });
+
+  it("returns an error for cat on a missing file", () => {
+    const result = executeCommand(createInitialState(), "cat missing-file");
+
+    expect(getLastNonInputLine(result.state)).toEqual({
+      text: "cat: missing-file: No such file or directory",
+      type: "error",
+    });
+  });
+
+  it("returns an error for cat on a directory", () => {
+    const result = executeCommand(createInitialState(), "cat work");
+
+    expect(getLastNonInputLine(result.state)).toEqual({
+      text: "cat: work: Is a directory",
+      type: "error",
+    });
+  });
+
+  it("echoes argument text", () => {
+    const result = executeCommand(createInitialState(), "echo hello terminal");
+
+    expect(getLastNonInputLine(result.state)).toEqual({
+      text: "hello terminal",
+      type: "output",
+    });
+  });
+
+  it("echo with no arguments returns an empty output line", () => {
+    const result = executeCommand(createInitialState(), "echo");
+
+    expect(getLastNonInputLine(result.state)).toEqual({ text: "", type: "output" });
+  });
+
+  it("history includes the current command when prior history is empty", () => {
+    const result = executeCommand(createInitialState(), "history");
+
+    expect(getNonInputLines(result.state)).toEqual([{ text: "1  history", type: "system" }]);
+  });
+
+  it("clear removes prior terminal output", () => {
+    const populated = executeCommand(createInitialState(), "help").state;
+    const cleared = executeCommand(populated, "clear");
+
+    expect(populated.output.length).toBeGreaterThan(0);
+    expect(cleared.state.output).toEqual([]);
+  });
+
+  it("returns the expected whoami output", () => {
+    const result = executeCommand(createInitialState(), "whoami");
+
+    expect(getLastNonInputLine(result.state)).toEqual({
+      text: "visitor -- browsing slen.win from [no tracking, we respect privacy]",
+      type: "output",
+    });
+  });
+
+  it("prints the current working directory", () => {
+    const state: TerminalState = {
+      ...createInitialState(),
+      cwd: "work",
+    };
+
+    const result = executeCommand(state, "pwd");
+
+    expect(getLastNonInputLine(result.state)).toEqual({ text: "work", type: "output" });
+  });
+
+  it("returns a command-not-found error for unknown commands", () => {
+    const result = executeCommand(createInitialState(), "foobar");
+
+    expect(getLastNonInputLine(result.state)).toEqual({
+      text: "command not found: foobar. Type 'help' for available commands.",
+      type: "error",
+    });
+  });
+
+  it("handles empty input without changing state", () => {
+    const state = createInitialState();
+    const result = executeCommand(state, "   ");
+
+    expect(result.state).toBe(state);
+    expect(result.navigate).toBeUndefined();
+    expect(result.state.output).toEqual([]);
+    expect(result.state.history).toEqual([]);
+  });
+
+  it.each<[string, string]>([
+    ["sudo", easterEggs.sudo[0]],
+    ["vim", easterEggs.vim[0]],
+    ["coffee", easterEggs.coffee[0]],
+    ["matrix", easterEggs.matrix[0]],
+  ])("returns easter egg output for %s", (command: string, expected: string) => {
+    const result = executeCommand(createInitialState(), command);
+
+    expect(getLastNonInputLine(result.state)).toEqual({ text: expected, type: "system" });
+  });
+
+  it("prefixes input lines with the configured prompt", () => {
+    const result = executeCommand(createInitialState(), "echo hi");
+
+    expect(result.state.output[0]).toEqual({
+      text: `${terminalConfig.prompt}echo hi`,
+      type: "input",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Combines former PRs #36 + #37 into one comprehensive test coverage PR.

**New test files** (4 files, 537 lines):
- `terminal.test.ts`: 15+ tests for executeCommand — all command branches, edge cases, easter eggs
- `github.test.ts`: 6+ tests for fetchGitHubPulse — error paths, pagination, commit counting
- `hooks.test.ts`: Tests for usePrefersReducedMotion and useSessionFlag isolation/error handling
- `shell-components.test.tsx`: Tests for BootSequence, CursorTrail, MatrixRain, HitMarker reduced-motion paths

**Coverage impact**: 37 → 79 unit tests (+42 new tests, +113% increase)

## Verification
- [x] TypeScript check passes
- [x] All 79 unit tests pass (14 test files)
- [x] Production build succeeds
- [x] No source files modified — test files only
- [x] No file overlap with other open PRs

Closes #13, Closes #23, Closes #27, Closes #28