### PR TITLE
fix: add error boundary for decorative components, fix audio leak, add memo

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import { MatrixRain } from "@/components/shell/MatrixRain";
 import { BootSequence } from "@/components/shell/BootSequence";
 import { CursorTrail } from "@/components/shell/CursorTrail";
 import { HitMarker } from "@/components/shell/HitMarker";
+import { ClientErrorBoundary } from "@/components/shell/ClientErrorBoundary";
 import { SubwayStatusBar } from "@/components/shell/SubwayStatusBar";
 import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
@@ -73,10 +74,12 @@ export default function RootLayout({
       className={`${spaceGrotesk.variable} ${ibmPlexMono.variable}`}
     >
       <body>
-        <BootSequence />
-        <CursorTrail />
-        <HitMarker />
-        <MatrixRain />
+        <ClientErrorBoundary>
+          <BootSequence />
+          <CursorTrail />
+          <HitMarker />
+          <MatrixRain />
+        </ClientErrorBoundary>
         <div className="scanline" aria-hidden="true" />
         <SkipLink />
         <Header />

--- a/src/components/home/PulseDashboard.tsx
+++ b/src/components/home/PulseDashboard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, memo } from "react";
 import { type GitHubEvent } from "@/lib/github";
 import { PulseAnimation } from "./PulseAnimation";
 
@@ -64,7 +64,7 @@ function rangeButtonStyle(active: boolean): React.CSSProperties {
   };
 }
 
-export function PulseDashboard({
+export const PulseDashboard = memo(function PulseDashboard({
   events,
   lastActive,
 }: {
@@ -269,4 +269,4 @@ export function PulseDashboard({
       </div>
     </div>
   );
-}
+});

--- a/src/components/shell/ClientErrorBoundary.tsx
+++ b/src/components/shell/ClientErrorBoundary.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { Component, type ReactNode, type ErrorInfo } from "react";
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export class ClientErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error("Decorative component error:", error, info);
+  }
+
+  render() {
+    if (this.state.hasError) return null;
+    return this.props.children;
+  }
+}

--- a/src/components/shell/HitMarker.tsx
+++ b/src/components/shell/HitMarker.tsx
@@ -22,18 +22,11 @@ export function HitMarker() {
   const prefersReducedMotion = usePrefersReducedMotion();
 
   useEffect(() => {
-    if (prefersReducedMotion) {
-      audioRef.current = null;
-      return;
+    if (!audioRef.current) {
+      audioRef.current = new Audio(HIT_SOUND);
+      audioRef.current.volume = 0.4;
     }
-
-    audioRef.current = new Audio(HIT_SOUND);
-    audioRef.current.volume = 0.4;
-
-    return () => {
-      audioRef.current = null;
-    };
-  }, [prefersReducedMotion]);
+  }, []);
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
## Summary
- Add `ClientErrorBoundary` wrapping BootSequence/CursorTrail/HitMarker/MatrixRain in layout
- Refactor HitMarker to create Audio element once via `useRef` instead of on every pref change
- Wrap `PulseDashboard` in `React.memo` to prevent unnecessary re-renders

## Verification
- [x] `pnpm typecheck` passes
- [x] `pnpm test run` passes (37/37)

Closes #50
Closes #52
Closes #53