### PR TITLE
test: expand E2E coverage for typing test flows and cross-page accessibility

### DIFF
--- a/tests/e2e/accessibility.spec.ts
+++ b/tests/e2e/accessibility.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from "@playwright/test";
+import AxeBuilder from "@axe-core/playwright";
+
+test.describe("Cross-page accessibility", () => {
+  test("about page passes accessibility checks", async ({ page }) => {
+    await page.goto("/about");
+    await expect(page.getByTestId("about-page-title")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).analyze();
+    expect(results.violations).toEqual([]);
+  });
+
+  test("work index passes accessibility checks", async ({ page }) => {
+    await page.goto("/work");
+    await expect(page.getByTestId("work-page-title")).toBeVisible();
+
+    const results = await new AxeBuilder({ page }).analyze();
+    expect(results.violations).toEqual([]);
+  });
+
+  test("case study page passes accessibility checks", async ({ page }) => {
+    await page.goto("/work/form-factor");
+    await page.locator("h1").waitFor({ state: "visible" });
+
+    const results = await new AxeBuilder({ page }).analyze();
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/tests/e2e/typing-test.spec.ts
+++ b/tests/e2e/typing-test.spec.ts
@@ -16,4 +16,38 @@ test.describe("Typing test", () => {
     await expect(typingTest).toContainText("accuracy");
     await expect(typingTest).toContainText("words");
   });
+
+  test("mode selector buttons switch word lists", async ({ page }) => {
+    const typingTest = page.getByTestId("typing-test");
+    const snippetsBtn = typingTest.getByRole("button", { name: "snippets" });
+
+    await expect(snippetsBtn).toBeVisible();
+    await snippetsBtn.click();
+
+    const activeMode = typingTest.locator("[data-testid='typing-test-mode-snippets']");
+    await expect(activeMode).toBeVisible();
+  });
+
+  test("time selector buttons are visible and clickable", async ({ page }) => {
+    const typingTest = page.getByTestId("typing-test");
+    const time60 = typingTest.getByRole("button", { name: "60" });
+
+    await expect(time60).toBeVisible();
+    await time60.click();
+
+    const timerDisplay = typingTest.getByTestId("typing-test-timer");
+    await expect(timerDisplay).toContainText("60");
+  });
+
+  test("Tab key resets an active run", async ({ page }) => {
+    const typingTest = page.getByTestId("typing-test");
+    await typingTest.click();
+    await page.keyboard.type("func");
+
+    await expect(typingTest).toContainText("wpm");
+
+    await page.keyboard.press("Tab");
+
+    await expect(typingTest).toContainText(/click here and start typing/i);
+  });
 });

--- a/tests/e2e/typing-test.spec.ts
+++ b/tests/e2e/typing-test.spec.ts
@@ -24,7 +24,7 @@ test.describe("Typing test", () => {
     await expect(snippetsBtn).toBeVisible();
     await snippetsBtn.click();
 
-    const activeMode = typingTest.locator("[data-testid='typing-test-mode-snippets']");
+    const activeMode = typingTest.locator("[data-testid='typing-mode-snippets']");
     await expect(activeMode).toBeVisible();
   });
 
@@ -35,8 +35,7 @@ test.describe("Typing test", () => {
     await expect(time60).toBeVisible();
     await time60.click();
 
-    const timerDisplay = typingTest.getByTestId("typing-test-timer");
-    await expect(timerDisplay).toContainText("60");
+    await expect(typingTest).toContainText("60s");
   });
 
   test("Tab key resets an active run", async ({ page }) => {


### PR DESCRIPTION
## Summary
- Expand typing test E2E: mode selection, time selection, Tab reset
- Add AxeBuilder accessibility checks for about, work index, and case study pages

## Verification
- [x] `pnpm typecheck` passes
- [x] `pnpm test run` passes (unit tests unaffected)
- [ ] E2E tests require `pnpm test:e2e` with server

Closes #59