### PR TITLE
fix(a11y): add aria-pressed to PulseDashboard range toggle buttons

### DIFF
--- a/src/components/home/PulseDashboard.tsx
+++ b/src/components/home/PulseDashboard.tsx
@@ -153,6 +153,7 @@ export function PulseDashboard({
             <button
               key={r.key}
               type="button"
+              aria-pressed={range === r.key}
               data-testid={`pulse-range-${r.key}`}
               style={rangeButtonStyle(range === r.key)}
               onClick={() => setRange(r.key)}


### PR DESCRIPTION
## Summary
- Adds `aria-pressed={range === r.key}` to each date-range toggle button (7d, 1m, 3m) in `PulseDashboard`
- Screen reader users can now determine which range is currently active
- No visual or behavioral changes; purely additive ARIA attribute

## Test plan
- [x] TypeScript compiles with no errors (`tsc --noEmit`)
- [x] All 37 unit tests pass
- [x] Production build succeeds

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)