### PR TITLE
fix(a11y): add aria context to resume PDF download links

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -270,6 +270,7 @@ export default function About() {
             target="_blank"
             rel="noopener noreferrer"
             data-testid="about-resume-download"
+            aria-label="Download resume PDF, opens in new tab"
             style={{
               display: "inline-flex",
               padding: "var(--space-3) var(--space-6)",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -401,6 +401,7 @@ export default function Home() {
                 href="/resume.pdf"
                 target="_blank"
                 rel="noopener noreferrer"
+                aria-label="Download resume PDF, opens in new tab"
                 style={{
                   display: "inline-flex",
                   padding: "var(--space-3) var(--space-6)",


### PR DESCRIPTION
## Summary
- Added `aria-label="Download resume PDF, opens in new tab"` to the resume PDF link in `src/app/page.tsx` (line 400)
- Added `aria-label="Download resume PDF, opens in new tab"` to the resume PDF link in `src/app/about/page.tsx` (line 268)
- No visual design changes — purely additive ARIA attribute on both anchor elements

## Test plan
- [ ] Verify with a screen reader (VoiceOver/NVDA) that both PDF links announce "Download resume PDF, opens in new tab"
- [ ] Confirm no visual layout changes on `/` and `/about` pages
- [ ] TypeScript check passes: `npx tsc --noEmit`
- [ ] All unit tests pass (37/37)
- [ ] Production build succeeds

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)