### PR TITLE
fix(config): move hardcoded GitHub username to siteConfig

### DIFF
--- a/src/components/home/GitHubCommitPulse.tsx
+++ b/src/components/home/GitHubCommitPulse.tsx
@@ -1,8 +1,10 @@
 import { fetchGitHubPulse } from "@/lib/github";
+import { siteConfig } from "@/content/site";
 import { PulseDashboard } from "./PulseDashboard";
 
 export async function GitHubCommitPulse() {
-  const data = await fetchGitHubPulse("ThyDrSlen");
+  const githubUsername = siteConfig.github?.username ?? "ThyDrSlen";
+  const data = await fetchGitHubPulse(githubUsername);
 
   if (!data) {
     return (
@@ -40,7 +42,7 @@ export async function GitHubCommitPulse() {
           signal unavailable {"// "}check GitHub
         </p>
         <a
-          href="https://github.com/ThyDrSlen"
+          href={`https://github.com/${githubUsername}`}
           target="_blank"
           rel="noopener noreferrer"
           className="mono"
@@ -50,7 +52,7 @@ export async function GitHubCommitPulse() {
             textDecoration: "none",
           }}
         >
-          github.com/ThyDrSlen &rarr;
+          github.com/{githubUsername} &rarr;
         </a>
       </div>
     );

--- a/src/content/site.ts
+++ b/src/content/site.ts
@@ -7,6 +7,9 @@ export const siteConfig: SiteConfig = {
     "Portfolio of Fabrizio Corrales. Backend-focused software engineer building scalable distributed systems, developer tooling, and platform capabilities.",
   url: "https://slen.win",
   email: "drslen9@gmail.com",
+  github: {
+    username: process.env.NEXT_PUBLIC_GITHUB_USERNAME ?? "ThyDrSlen",
+  },
   socialLinks: [
     {
       platform: "github",

--- a/src/lib/content-schema.ts
+++ b/src/lib/content-schema.ts
@@ -13,6 +13,11 @@ export const siteConfigSchema = z.object({
   url: z.url(),
   email: z.email(),
   socialLinks: z.array(socialLinkSchema).min(1),
+  github: z
+    .object({
+      username: z.string().min(1),
+    })
+    .optional(),
 });
 
 export const experienceEntrySchema = z.object({


### PR DESCRIPTION
## Summary

- Adds an optional `github.username` field to `siteConfigSchema` in `src/lib/content-schema.ts`
- Populates `siteConfig.github.username` in `src/content/site.ts` using `NEXT_PUBLIC_GITHUB_USERNAME` env var with `"ThyDrSlen"` as fallback
- Updates `GitHubCommitPulse` component to read username from `siteConfig.github?.username ?? "ThyDrSlen"` instead of a hardcoded literal (including the fallback href/label in the error state)

## Test plan

- [x] `npx tsc --noEmit` — no type errors
- [x] All 37 unit tests pass (`vitest --run`)
- [x] Production build succeeds (`next build`)
- [x] Setting `NEXT_PUBLIC_GITHUB_USERNAME=<other>` will use that value; omitting it falls back to `"ThyDrSlen"`

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)