### PR TITLE
fix(seo): add openGraph.url to case study generateMetadata

### DIFF
--- a/src/app/work/[slug]/page.tsx
+++ b/src/app/work/[slug]/page.tsx
@@ -28,6 +28,7 @@ export async function generateMetadata({
       title: `${cs.title} | ${siteConfig.name}`,
       description: cs.summary,
       type: "article",
+      url: `${siteConfig.url}/work/${slug}`,
     },
   };
 }


### PR DESCRIPTION
## Summary
- Adds `url: \`${siteConfig.url}/work/${slug}\`` to `openGraph` inside `generateMetadata` in `src/app/work/[slug]/page.tsx`
- `siteConfig.url` is already defined as `"https://slen.win"` in `src/content/site.ts`

## Test plan
- [x] TypeScript compiles cleanly
- [x] All 37+ unit tests pass

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)