### PR TITLE
fix(dx): ignore .claude agent worktrees in ESLint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,8 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+    // Ignore Claude Code agent worktrees
+    ".claude/**",
   ]),
 ]);
 


### PR DESCRIPTION
## Summary
- Adds `.claude/**` to `globalIgnores()` in `eslint.config.mjs`
- Prevents lint warnings from leaking out of Claude Code parallel agent worktrees created under `.claude/worktrees/`

## Test plan
- [x] ESLint runs cleanly with no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)