### PR TITLE
fix(security): add frame-ancestors 'none' to Content-Security-Policy

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -8,6 +8,7 @@ const contentSecurityPolicy = [
   "font-src 'self' https://fonts.gstatic.com",
   "media-src 'self' data: blob:",
   "img-src 'self' data: blob:",
+  "frame-ancestors 'none'",
 ].join("; ");
 
 const nextConfig: NextConfig = {


### PR DESCRIPTION
## Summary

- Adds `frame-ancestors 'none'` as the last directive in the CSP header array in `next.config.ts`
- Prevents the site from being embedded in any `<frame>`, `<iframe>`, `<object>`, or `<embed>` — complementing the existing `X-Frame-Options: DENY` header with a modern CSP equivalent

## Test plan

- [ ] TypeScript: `npx tsc --noEmit` passes with no errors
- [ ] Verify the `Content-Security-Policy` response header on any route includes `frame-ancestors 'none'`
- [ ] Confirm no regressions in existing pre-push checks (lint, typecheck, unit tests, build)

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)