### PR TITLE
fix(shell): stop and dereference Audio on unmount and motion pref change

### DIFF
--- a/src/components/shell/HitMarker.tsx
+++ b/src/components/shell/HitMarker.tsx
@@ -23,14 +23,21 @@ export function HitMarker() {
 
   useEffect(() => {
     if (prefersReducedMotion) {
-      audioRef.current = null;
+      if (audioRef.current) {
+        audioRef.current.pause();
+        audioRef.current.src = "";
+        audioRef.current = null;
+      }
       return;
     }
 
-    audioRef.current = new Audio(HIT_SOUND);
-    audioRef.current.volume = 0.4;
+    const audio = new Audio(HIT_SOUND);
+    audio.volume = 0.4;
+    audioRef.current = audio;
 
     return () => {
+      audio.pause();
+      audio.src = "";
       audioRef.current = null;
     };
   }, [prefersReducedMotion]);


### PR DESCRIPTION
## Summary

- When `prefersReducedMotion` becomes `true` mid-session, any in-progress `Audio` instance is now explicitly paused and its `src` cleared before the ref is nulled — preventing the element from continuing to hold network/decode resources.
- The `useEffect` cleanup function captures the local `audio` variable (not `audioRef.current`) so the correct instance is always stopped on unmount, even if the ref was reassigned in the interim.
- Setting `audio.src = ""` causes the browser to release the underlying media resource immediately rather than waiting for GC.

Partially addresses #52 (audio leak only; base64 bundle-size issue tracked separately).

## Test plan

- [ ] Toggle OS reduced-motion preference while the site is open and a hit-marker sound is mid-play — confirm audio stops immediately.
- [ ] Navigate away from the page during playback — confirm no console errors and audio halts.
- [ ] Normal click interactions with reduced-motion off still produce hit-marker sound and animation as expected.
- [ ] `npx tsc --noEmit` reports zero errors.
- [ ] All 37 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)