### PR TITLE
fix(shell): hoist matchMedia to prevent CursorTrail listener accumulation

### DIFF
--- a/src/components/shell/CursorTrail.tsx
+++ b/src/components/shell/CursorTrail.tsx
@@ -13,14 +13,21 @@ const MAX_POINTS = 20;
 const LIFETIME = 500;
 const IDLE_GRACE_MS = 100;
 
+// Hoisted to module level so addEventListener and removeEventListener
+// always operate on the same stable MediaQueryList instance,
+// preventing listener accumulation when useSyncExternalStore re-subscribes.
+const pointerMql =
+  typeof window !== "undefined"
+    ? window.matchMedia("(pointer: fine)")
+    : null;
+
 function subscribePointer(callback: () => void) {
-  const mql = window.matchMedia("(pointer: fine)");
-  mql.addEventListener("change", callback);
-  return () => mql.removeEventListener("change", callback);
+  pointerMql?.addEventListener("change", callback);
+  return () => pointerMql?.removeEventListener("change", callback);
 }
 
 function getPointerSnapshot() {
-  return window.matchMedia("(pointer: fine)").matches;
+  return pointerMql?.matches ?? false;
 }
 
 // Frame skip by hardwareConcurrency: 1 (8+ cores), 2 (3–4), 3 (≤2)


### PR DESCRIPTION
## Summary

- Hoists `window.matchMedia("(pointer: fine)")` to a module-level constant (`pointerMql`) in `CursorTrail.tsx`
- `subscribePointer` now calls `addEventListener`/`removeEventListener` on the same stable `MediaQueryList` instance, so cleanup actually removes the correct listener
- Guards against SSR with a `typeof window !== "undefined"` check; `getPointerSnapshot` falls back to `false` when `pointerMql` is null
- `getPointerSnapshot` updated to read `pointerMql?.matches` instead of calling `window.matchMedia` a second time

Closes #119

## Test plan

- [ ] Verify cursor trail renders on a desktop (pointer: fine) device
- [ ] Verify no cursor trail on a touch/coarse-pointer device
- [ ] Inspect DevTools → Event Listeners on `window` — confirm no duplicate `change` listener accumulation across re-renders
- [ ] `npx tsc --noEmit` passes with no errors
- [ ] `npm run lint` passes (pre-existing unrelated ENOENT for missing test file is not introduced by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)