### PR TITLE
fix(a11y): make PulseAnimation aria-label reflect active date range

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,8 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+    // Agent worktrees (nested repos — do not lint):
+    ".claude/worktrees/**",
   ]),
 ]);
 

--- a/src/components/home/PulseAnimation.tsx
+++ b/src/components/home/PulseAnimation.tsx
@@ -24,8 +24,10 @@ function buildPoints(
 
 export function PulseAnimation({
   commitsByDay,
+  rangeLabel = "7 days",
 }: {
   commitsByDay: DayData[];
+  rangeLabel?: string;
 }) {
   const W = 400;
   const H = 120;
@@ -61,7 +63,7 @@ export function PulseAnimation({
       preserveAspectRatio="xMidYMid meet"
       style={{ display: "block" }}
       role="img"
-      aria-label="GitHub commit activity over the last 7 days"
+      aria-label={`GitHub commit activity over the last ${rangeLabel}`}
     >
       <defs>
         <filter id="pulse-glow">

--- a/src/components/home/PulseDashboard.tsx
+++ b/src/components/home/PulseDashboard.tsx
@@ -6,10 +6,10 @@ import { PulseAnimation } from "./PulseAnimation";
 
 type Range = 7 | 30 | 90;
 
-const RANGES: { key: Range; label: string }[] = [
-  { key: 7, label: "7d" },
-  { key: 30, label: "1m" },
-  { key: 90, label: "3m" },
+const RANGES: { key: Range; label: string; ariaLabel: string }[] = [
+  { key: 7, label: "7d", ariaLabel: "7 days" },
+  { key: 30, label: "1m", ariaLabel: "30 days" },
+  { key: 90, label: "3m", ariaLabel: "90 days" },
 ];
 
 function computeWindow(events: GitHubEvent[], days: Range) {
@@ -164,7 +164,10 @@ export function PulseDashboard({
       </div>
 
       <div style={{ marginBottom: "var(--space-6)" }}>
-        <PulseAnimation commitsByDay={sampledDays} />
+        <PulseAnimation
+          commitsByDay={sampledDays}
+          rangeLabel={RANGES.find((r) => r.key === range)?.ariaLabel ?? "7 days"}
+        />
       </div>
 
       <div


### PR DESCRIPTION
## Summary

- Adds an optional `rangeLabel?: string` prop to `PulseAnimation` (defaults to `"7 days"` to preserve existing behaviour)
- Updates the SVG `aria-label` from the hardcoded `"GitHub commit activity over the last 7 days"` to a dynamic template literal using `rangeLabel`
- Adds an `ariaLabel` field to the `RANGES` config in `PulseDashboard` (`"7 days"`, `"30 days"`, `"90 days"`) and passes the active range's label down to `PulseAnimation`
- Also fixes a pre-existing ESLint infrastructure issue where `.claude/worktrees/**` was not ignored, causing ESLint to lint build artifacts inside other agents' worktrees

Closes #107

## Test plan

- [ ] Switch the range selector between 7d / 1m / 3m and confirm the SVG `aria-label` updates in DevTools (Accessibility panel or Elements inspector)
- [ ] Default render (7d) still reads `"GitHub commit activity over the last 7 days"`
- [ ] 30d reads `"GitHub commit activity over the last 30 days"`
- [ ] 90d reads `"GitHub commit activity over the last 90 days"`
- [ ] TypeScript compiles cleanly (`npx tsc --noEmit`) — no new errors
- [ ] Pre-push lint, typecheck, unit tests, and build all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)