### PR TITLE
fix(ux): add hover and focus-visible styles to about page social links

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -251,17 +251,7 @@ export default function About() {
           <a
             href={`mailto:${siteConfig.email}`}
             data-testid="contact-email-link"
-            style={{
-              display: "inline-flex",
-              padding: "var(--space-3) var(--space-6)",
-              background: "var(--color-text)",
-              color: "var(--color-bg)",
-              fontFamily: "var(--font-mono)",
-              fontSize: "var(--text-sm)",
-              fontWeight: 600,
-              borderRadius: "var(--radius-md)",
-              textDecoration: "none",
-            }}
+            className="about-contact-link about-contact-link--primary"
           >
             Email me
           </a>
@@ -270,16 +260,7 @@ export default function About() {
             target="_blank"
             rel="noopener noreferrer"
             data-testid="about-resume-download"
-            style={{
-              display: "inline-flex",
-              padding: "var(--space-3) var(--space-6)",
-              border: "1px solid var(--color-border)",
-              fontFamily: "var(--font-mono)",
-              fontSize: "var(--text-sm)",
-              borderRadius: "var(--radius-md)",
-              textDecoration: "none",
-              color: "var(--color-text-secondary)",
-            }}
+            className="about-contact-link about-contact-link--outline"
           >
             Download Resume
           </a>
@@ -288,16 +269,7 @@ export default function About() {
             target="_blank"
             rel="noopener noreferrer"
             data-testid="social-link-github"
-            style={{
-              display: "inline-flex",
-              padding: "var(--space-3) var(--space-6)",
-              border: "1px solid var(--color-border)",
-              fontFamily: "var(--font-mono)",
-              fontSize: "var(--text-sm)",
-              borderRadius: "var(--radius-md)",
-              textDecoration: "none",
-              color: "var(--color-text-secondary)",
-            }}
+            className="about-contact-link about-contact-link--outline"
           >
             GitHub
           </a>
@@ -306,16 +278,7 @@ export default function About() {
             target="_blank"
             rel="noopener noreferrer"
             data-testid="social-link-linkedin"
-            style={{
-              display: "inline-flex",
-              padding: "var(--space-3) var(--space-6)",
-              border: "1px solid var(--color-border)",
-              fontFamily: "var(--font-mono)",
-              fontSize: "var(--text-sm)",
-              borderRadius: "var(--radius-md)",
-              textDecoration: "none",
-              color: "var(--color-text-secondary)",
-            }}
+            className="about-contact-link about-contact-link--outline"
           >
             LinkedIn
           </a>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -316,6 +316,53 @@ a {
   margin: 0 auto;
 }
 
+/* ── About Page Contact Links ── */
+.about-contact-link {
+  display: inline-flex;
+  padding: var(--space-3) var(--space-6);
+  border-radius: var(--radius-md);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  text-decoration: none;
+  transition: color var(--duration-fast) var(--easing),
+    background var(--duration-fast) var(--easing),
+    border-color var(--duration-fast) var(--easing),
+    box-shadow var(--duration-fast) var(--easing);
+}
+
+.about-contact-link--primary {
+  background: var(--color-text);
+  color: var(--color-bg);
+  font-weight: 600;
+}
+
+.about-contact-link--primary:hover {
+  background: var(--color-accent);
+  color: var(--color-bg);
+  box-shadow: 0 0 12px var(--color-accent-glow);
+}
+
+.about-contact-link--primary:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.about-contact-link--outline {
+  border: 1px solid var(--color-border);
+  color: var(--color-text-secondary);
+}
+
+.about-contact-link--outline:hover {
+  border-color: var(--color-accent-dim);
+  color: var(--color-accent);
+  box-shadow: 0 0 8px var(--color-accent-glow);
+}
+
+.about-contact-link--outline:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
 /* ── Matrix Rain Canvas ── */
 .matrix-rain {
   position: fixed;


### PR DESCRIPTION
## Summary

- Adds `.about-contact-link`, `.about-contact-link--primary`, and `.about-contact-link--outline` CSS classes to `globals.css`
- Replaces inline styles on the four "Get in Touch" anchors (Email me, Download Resume, GitHub, LinkedIn) with those classes
- Primary button hovers to accent green with a glow; outline buttons hover to accent color with border highlight and glow
- `focus-visible` ring on both variants is consistent with the app-wide `:focus-visible` rule (`2px solid var(--color-accent)`)
- Transitions follow existing app patterns (`--duration-fast`, `--easing`) and respect `prefers-reduced-motion`

## Test plan

- [ ] Visit `/about` and hover each "Get in Touch" link — confirm color/glow transition
- [ ] Tab through the links with keyboard — confirm visible focus ring on each
- [ ] Verify styles are consistent with header nav and footer social links
- [ ] Confirm no regression in existing unit tests (37 pass) and build

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)