### PR TITLE
fix(a11y): add aria-current to active Header nav link (#76)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,8 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+    // Ignore Claude Code worktree copies of the project:
+    ".claude/worktrees/**",
   ]),
 ]);
 

--- a/src/components/shell/Header.tsx
+++ b/src/components/shell/Header.tsx
@@ -1,6 +1,18 @@
+"use client";
+
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 
 export function Header() {
+  const currentPath = usePathname();
+
+  const getAriaCurrent = (href: string) => {
+    if (href === "/") {
+      return currentPath === "/" ? "page" : undefined;
+    }
+    return currentPath.startsWith(href) ? "page" : undefined;
+  };
+
   return (
     <header className="site-header" data-testid="site-shell">
       <div className="site-header-inner">
@@ -8,10 +20,18 @@ export function Header() {
           slen.win
         </Link>
         <nav className="site-nav" data-testid="primary-nav">
-          <Link href="/work" data-testid="nav-link-work">
+          <Link
+            href="/work"
+            data-testid="nav-link-work"
+            aria-current={getAriaCurrent("/work")}
+          >
             Work
           </Link>
-          <Link href="/about" data-testid="nav-link-about">
+          <Link
+            href="/about"
+            data-testid="nav-link-about"
+            aria-current={getAriaCurrent("/about")}
+          >
             About
           </Link>
           <a

--- a/src/components/shell/Header.tsx
+++ b/src/components/shell/Header.tsx
@@ -7,6 +7,7 @@ export function Header() {
   const currentPath = usePathname();
 
   const getAriaCurrent = (href: string) => {
+    if (!currentPath) return undefined;
     if (href === "/") {
       return currentPath === "/" ? "page" : undefined;
     }

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,6 +1,12 @@
 import "@testing-library/jest-dom/vitest";
 import { cleanup } from "@testing-library/react";
-import { afterEach, beforeEach } from "vitest";
+import { afterEach, beforeEach, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/",
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), prefetch: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}));
 
 beforeEach(() => {
   Object.defineProperty(window, "matchMedia", {


### PR DESCRIPTION
## Summary

- Adds `'use client'` directive and imports `usePathname` from `next/navigation` in `Header.tsx`
- Computes `aria-current="page"` on the active nav link using exact match for `/` and `startsWith` for sub-routes (e.g. `/work/slug` marks `/work` as active)
- Guards against `null` from `usePathname()` when rendered outside a Next.js router context
- Mocks `next/navigation` in the global Vitest setup so existing Header unit tests continue to pass
- Adds `.claude/worktrees/**` to ESLint ignore list to prevent build-artifact lint noise from other agent worktrees

Closes #76

## Test plan

- [ ] Navigate to `/` — no nav link has `aria-current`
- [ ] Navigate to `/work` — Work link has `aria-current="page"`
- [ ] Navigate to `/work/some-slug` — Work link still has `aria-current="page"` (startsWith match)
- [ ] Navigate to `/about` — About link has `aria-current="page"`
- [ ] Verify Resume `<a>` tag has no `aria-current` (static external link)
- [ ] `pnpm test -- --run` passes (37 tests)
- [ ] `pnpm typecheck` exits 0
- [ ] `pnpm lint` exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)