### PR TITLE
fix(types): use satisfies operator in case-studies.ts for compile-time validation

### DIFF
--- a/src/app/work/page.tsx
+++ b/src/app/work/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { caseStudies } from "@/content/case-studies";
+import type { CaseStudy } from "@/lib/content-schema";
 
 export const metadata: Metadata = {
   title: "Work",
@@ -33,7 +34,7 @@ export default function WorkIndex() {
           gap: "var(--space-6)",
         }}
       >
-        {caseStudies.map((cs) => (
+        {(caseStudies as CaseStudy[]).map((cs) => (
           <Link
             key={cs.slug}
             href={`/work/${cs.slug}`}

--- a/src/content/case-studies.ts
+++ b/src/content/case-studies.ts
@@ -1,6 +1,6 @@
 import { validateCaseStudies, type CaseStudy } from "@/lib/content-schema";
 
-export const caseStudies: CaseStudy[] = [
+export const caseStudies = [
   {
     slug: "form-factor",
     title: "Form Factor",
@@ -342,7 +342,7 @@ export const caseStudies: CaseStudy[] = [
     },
     featured: true,
   },
-];
+] satisfies CaseStudy[];
 
 export function getCaseStudyBySlug(slug: string): CaseStudy | undefined {
   return caseStudies.find((cs) => cs.slug === slug);


### PR DESCRIPTION
## Summary

- Replaces `export const caseStudies: CaseStudy[] = [...]` with `export const caseStudies = [...] satisfies CaseStudy[]` in `src/content/case-studies.ts`
- The `satisfies` operator validates the array against `CaseStudy[]` at compile time while preserving literal types — unlike an explicit type annotation which widens and silently swallows type errors
- This surfaced a TS2367 error in `src/app/work/page.tsx` where `cs.disclosure.anonymizationLevel === "anonymized"` was always-false (all current entries use `"none"`); fixed by casting at the `.map()` call site so the comparison is evaluated against the full schema union

## Test plan

- [x] `tsc --noEmit` passes with zero errors
- [x] All 37 unit tests pass (`vitest --run`)
- [x] No lint errors introduced

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)