### PR TITLE
test(infra): add coverage thresholds to vitest and clear localStorage in setup

### DIFF
--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -36,6 +36,7 @@ beforeEach(() => {
   }
 
   sessionStorage.clear();
+  localStorage.clear();
 });
 
 afterEach(() => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,16 @@ export default defineConfig({
     environment: "jsdom",
     setupFiles: ["./src/test/setup.ts"],
     include: ["src/**/*.test.{ts,tsx}"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html"],
+      thresholds: {
+        lines: 60,
+        functions: 60,
+        branches: 50,
+        statements: 60,
+      },
+    },
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary

- **#151**: Added `coverage` config to `vitest.config.ts` with `v8` provider and thresholds (lines: 60, functions: 60, branches: 50, statements: 60) to catch regressions via CI coverage gating.
- **#152**: Added `localStorage.clear()` alongside the existing `sessionStorage.clear()` in the `beforeEach` block of `src/test/setup.ts` to prevent cross-test state bleed from localStorage.

## Test plan

- [x] All 37 unit tests pass (`vitest run`)
- [x] Lint passes (warnings only, no errors)
- [x] TypeScript check passes
- [x] Production build succeeds

Closes #151
Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)