### PR TITLE
test(meta): add unit tests for robots.ts and sitemap.ts

### DIFF
--- a/src/test/robots.test.ts
+++ b/src/test/robots.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import robots from "@/app/robots";
+import { siteConfig } from "@/content/site";
+
+describe("robots()", () => {
+  it("returns an object with a rules property", () => {
+    const result = robots();
+    expect(result).toHaveProperty("rules");
+  });
+
+  it("rules.allow includes '/'", () => {
+    const result = robots();
+    const { rules } = result;
+    const allow = Array.isArray(rules)
+      ? rules.flatMap((r) => (Array.isArray(r.allow) ? r.allow : [r.allow]))
+      : Array.isArray(rules.allow)
+        ? rules.allow
+        : [rules.allow];
+    expect(allow).toContain("/");
+  });
+
+  it("sitemap property points to <siteUrl>/sitemap.xml", () => {
+    const result = robots();
+    const expected = `${siteConfig.url}/sitemap.xml`;
+    const sitemaps = Array.isArray(result.sitemap)
+      ? result.sitemap
+      : [result.sitemap];
+    expect(sitemaps).toContain(expected);
+  });
+
+  it("userAgent rule covers all agents", () => {
+    const result = robots();
+    const { rules } = result;
+    const agents = Array.isArray(rules)
+      ? rules.map((r) => r.userAgent)
+      : [rules.userAgent];
+    expect(agents).toContain("*");
+  });
+});

--- a/src/test/sitemap.test.ts
+++ b/src/test/sitemap.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import sitemap from "@/app/sitemap";
+import { siteConfig } from "@/content/site";
+import { getAllSlugs } from "@/content/case-studies";
+
+describe("sitemap()", () => {
+  it("returns an array", () => {
+    const result = sitemap();
+    expect(Array.isArray(result)).toBe(true);
+  });
+
+  it("array is non-empty", () => {
+    const result = sitemap();
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it("every entry has a url string", () => {
+    const result = sitemap();
+    for (const entry of result) {
+      expect(typeof entry.url).toBe("string");
+      expect(entry.url.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("every entry has a lastModified Date", () => {
+    const result = sitemap();
+    for (const entry of result) {
+      expect(entry.lastModified).toBeInstanceOf(Date);
+    }
+  });
+
+  it("includes the home page URL", () => {
+    const result = sitemap();
+    const urls = result.map((e) => e.url);
+    expect(urls).toContain(siteConfig.url);
+  });
+
+  it("includes the /work page URL", () => {
+    const result = sitemap();
+    const urls = result.map((e) => e.url);
+    expect(urls).toContain(`${siteConfig.url}/work`);
+  });
+
+  it("includes the /about page URL", () => {
+    const result = sitemap();
+    const urls = result.map((e) => e.url);
+    expect(urls).toContain(`${siteConfig.url}/about`);
+  });
+
+  it("includes a URL for every case study slug", () => {
+    const result = sitemap();
+    const urls = result.map((e) => e.url);
+    const slugs = getAllSlugs();
+    for (const slug of slugs) {
+      expect(urls).toContain(`${siteConfig.url}/work/${slug}`);
+    }
+  });
+
+  it("case study slugs include form-factor, orwell-scraper, palo-alto, portus", () => {
+    const result = sitemap();
+    const urls = result.map((e) => e.url);
+    const expectedSlugs = ["form-factor", "orwell-scraper", "palo-alto", "portus"];
+    for (const slug of expectedSlugs) {
+      expect(urls).toContain(`${siteConfig.url}/work/${slug}`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `src/test/robots.test.ts` with 4 tests covering `robots()` return shape, `rules.allow` including `"/"`, `sitemap` property pointing to `<siteUrl>/sitemap.xml`, and userAgent coverage
- Adds `src/test/sitemap.test.ts` with 9 tests covering array return, non-empty result, per-entry `url` and `lastModified` types, home/work/about static routes, and all 4 case study slug URLs (`form-factor`, `orwell-scraper`, `palo-alto`, `portus`)
- All 13 new tests pass; full suite goes from 37 to 50 tests with no regressions

## Test plan

- [x] `npx vitest run src/test/robots.test.ts src/test/sitemap.test.ts` — 13/13 pass
- [x] Full suite `pnpm test --run` — 50/50 pass
- [x] Lint and typecheck clean
- [x] Production build succeeds

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)