### PR TITLE
perf(home): memoize PulseAnimation point/polyline calculations with useMemo

### DIFF
--- a/src/components/home/PulseAnimation.tsx
+++ b/src/components/home/PulseAnimation.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
 
 type DayData = { date: string; count: number };
@@ -22,7 +22,7 @@ function buildPoints(
   }));
 }
 
-export function PulseAnimation({
+function PulseAnimationInner({
   commitsByDay,
 }: {
   commitsByDay: DayData[];
@@ -35,14 +35,25 @@ export function PulseAnimation({
   const lineRef = useRef<SVGPolylineElement>(null);
   const prefersReducedMotion = usePrefersReducedMotion();
 
-  const points = buildPoints(commitsByDay, W, H, PAD_X, PAD_Y);
-  const polyline = points.map((p) => `${p.x},${p.y}`).join(" ");
+  const points = useMemo(
+    () => buildPoints(commitsByDay, W, H, PAD_X, PAD_Y),
+    [commitsByDay]
+  );
 
-  const totalLength = points.reduce((acc, p, i) => {
-    if (i === 0) return 0;
-    const prev = points[i - 1];
-    return acc + Math.sqrt((p.x - prev.x) ** 2 + (p.y - prev.y) ** 2);
-  }, 0);
+  const polyline = useMemo(
+    () => points.map((p) => `${p.x},${p.y}`).join(" "),
+    [points]
+  );
+
+  const totalLength = useMemo(
+    () =>
+      points.reduce((acc, p, i) => {
+        if (i === 0) return 0;
+        const prev = points[i - 1];
+        return acc + Math.sqrt((p.x - prev.x) ** 2 + (p.y - prev.y) ** 2);
+      }, 0),
+    [points]
+  );
 
   useEffect(() => {
     if (prefersReducedMotion) {
@@ -170,3 +181,5 @@ export function PulseAnimation({
     </svg>
   );
 }
+
+export const PulseAnimation = React.memo(PulseAnimationInner);


### PR DESCRIPTION
## Summary

- Wraps `buildPoints()` call in `useMemo([commitsByDay])` so point coordinates are only recalculated when the commit data changes
- Wraps polyline string construction in `useMemo([points])` so the `x,y` join is skipped on unrelated re-renders
- Wraps `totalLength` Euclidean distance reduction in `useMemo([points])` for the same reason
- Wraps the component with `React.memo` to prevent re-renders when the parent re-renders with stable props

Before this change all three computations (O(n) map, O(n) join, O(n) reduce) ran unconditionally on every render. After, they only run when `commitsByDay` reference changes.

PR #147 (dynamic `rangeLabel`/aria-label) was not present on this branch; no pre-existing PR-147 changes were removed.

## Test plan

- [ ] `npx tsc --noEmit` passes (verified — zero errors)
- [ ] Visually verify the PulseAnimation still renders and animates correctly on the home page
- [ ] Confirm no React hook order warnings in the browser console

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)