### PR TITLE
fix(ux): add error fallback to GitHubCommitPulse server component

### DIFF
--- a/src/components/home/GitHubCommitPulse.tsx
+++ b/src/components/home/GitHubCommitPulse.tsx
@@ -1,60 +1,69 @@
 import { fetchGitHubPulse } from "@/lib/github";
 import { PulseDashboard } from "./PulseDashboard";
 
-export async function GitHubCommitPulse() {
-  const data = await fetchGitHubPulse("ThyDrSlen");
-
-  if (!data) {
-    return (
+function GitHubPulseFallback() {
+  return (
+    <div
+      data-testid="github-commit-pulse"
+      style={{
+        padding: "var(--space-8)",
+        background: "var(--color-bg-elevated)",
+        border: "1px solid var(--color-border)",
+        borderRadius: "var(--radius-lg)",
+        position: "relative",
+        overflow: "hidden",
+      }}
+    >
       <div
-        data-testid="github-commit-pulse"
         style={{
-          padding: "var(--space-8)",
-          background: "var(--color-bg-elevated)",
-          border: "1px solid var(--color-border)",
-          borderRadius: "var(--radius-lg)",
-          position: "relative",
-          overflow: "hidden",
+          position: "absolute",
+          top: 0,
+          left: 0,
+          right: 0,
+          height: "1px",
+          background:
+            "linear-gradient(90deg, transparent, var(--color-accent), transparent)",
+          opacity: 0.5,
+        }}
+      />
+      <p
+        className="mono"
+        style={{
+          fontSize: "var(--text-sm)",
+          color: "var(--color-text-muted)",
+          marginBottom: "var(--space-4)",
         }}
       >
-        <div
-          style={{
-            position: "absolute",
-            top: 0,
-            left: 0,
-            right: 0,
-            height: "1px",
-            background:
-              "linear-gradient(90deg, transparent, var(--color-accent), transparent)",
-            opacity: 0.5,
-          }}
-        />
-        <p
-          className="mono"
-          style={{
-            fontSize: "var(--text-sm)",
-            color: "var(--color-text-muted)",
-            marginBottom: "var(--space-4)",
-          }}
-        >
-          signal unavailable {"// "}check GitHub
-        </p>
-        <a
-          href="https://github.com/ThyDrSlen"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="mono"
-          style={{
-            fontSize: "var(--text-sm)",
-            color: "var(--color-accent)",
-            textDecoration: "none",
-          }}
-        >
-          github.com/ThyDrSlen &rarr;
-        </a>
-      </div>
-    );
+        signal unavailable {"// "}check GitHub
+      </p>
+      <a
+        href="https://github.com/ThyDrSlen"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="mono"
+        style={{
+          fontSize: "var(--text-sm)",
+          color: "var(--color-accent)",
+          textDecoration: "none",
+        }}
+      >
+        github.com/ThyDrSlen &rarr;
+      </a>
+    </div>
+  );
+}
+
+export async function GitHubCommitPulse() {
+  let data = null;
+
+  try {
+    data = await fetchGitHubPulse("ThyDrSlen");
+  } catch {
+    // fetchGitHubPulse already catches internally, but guard against any
+    // unexpected throw so the dashboard never propagates to the page error boundary.
   }
+
+  if (!data) return <GitHubPulseFallback />;
 
   return <PulseDashboard events={data.events} lastActive={data.lastActive} />;
 }


### PR DESCRIPTION
## Summary

- Wraps the `fetchGitHubPulse` call in `GitHubCommitPulse` with a `try/catch` so any unexpected throw is caught at the component level instead of propagating to the Next.js page error boundary
- Extracts the inline fallback JSX into a named `GitHubPulseFallback` component, reused by both the `null`-data path and the caught-error path
- Pattern satisfies the `react-hooks/error-boundaries` ESLint rule: only the async fetch is inside try/catch; JSX is returned outside it

## Test plan

- [ ] Verify lint passes: `npm run lint`
- [ ] Verify TypeScript passes: `npm run typecheck`
- [ ] Verify unit tests pass: `npm test`
- [ ] Manually verify the fallback UI renders when GitHub API is unreachable (e.g., block the request via DevTools Network tab or set an invalid token)
- [ ] Verify the main dashboard page does not break when the fallback is shown

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)