### PR TITLE
perf(shell): throttle CursorTrail mousemove to rAF cadence (~60fps)

### DIFF
--- a/src/components/shell/CursorTrail.tsx
+++ b/src/components/shell/CursorTrail.tsx
@@ -49,6 +49,7 @@ export function CursorTrail() {
     let rendering = false;
     let frameCount = 0;
     const frameSkip = getFrameSkip();
+    let rafId: number | null = null;
 
     const trail: TrailPoint[] = [];
     let mouseX = 0;
@@ -134,17 +135,21 @@ export function CursorTrail() {
     };
 
     const onMouseMove = (e: MouseEvent) => {
-      mouseX = e.clientX;
-      mouseY = e.clientY;
-      mouseActive = true;
-      lastMoveTime = Date.now();
+      if (rafId !== null) return; // already scheduled, skip until next frame
+      rafId = requestAnimationFrame(() => {
+        rafId = null;
+        mouseX = e.clientX;
+        mouseY = e.clientY;
+        mouseActive = true;
+        lastMoveTime = Date.now();
 
-      trail.push({ x: mouseX, y: mouseY, timestamp: lastMoveTime });
-      if (trail.length > MAX_POINTS) {
-        trail.shift();
-      }
+        trail.push({ x: mouseX, y: mouseY, timestamp: lastMoveTime });
+        if (trail.length > MAX_POINTS) {
+          trail.shift();
+        }
 
-      startRendering();
+        startRendering();
+      });
     };
 
     document.addEventListener("mousemove", onMouseMove);
@@ -152,6 +157,7 @@ export function CursorTrail() {
 
     return () => {
       cancelAnimationFrame(animationId);
+      if (rafId !== null) cancelAnimationFrame(rafId);
       document.removeEventListener("mousemove", onMouseMove);
       window.removeEventListener("resize", resize);
     };


### PR DESCRIPTION
## Summary

- The `mousemove` listener in `CursorTrail` was firing at the raw device polling rate (up to 240Hz on gaming mice), running trail-update logic far more often than the display can render
- Added a `requestAnimationFrame` gate: each call to `onMouseMove` schedules one rAF callback; subsequent events are dropped until that frame fires, capping state updates to ~60fps
- Added `cancelAnimationFrame(rafId)` in the effect cleanup to ensure no stale callback runs after unmount or dependency change
- All existing logic (PR #144's `subscribePointer`/`getPointerSnapshot` matchMedia pattern, `frameSkip` heuristic, idle auto-stop) is preserved unchanged

## Test plan

- [ ] Move mouse on a 240Hz device; confirm trail renders correctly without visible degradation vs. before
- [ ] Verify trail still fades/clears when cursor is idle
- [ ] Confirm no console errors on mount/unmount (e.g. rapidly toggle desktop/mobile viewport)
- [ ] TypeScript: `npx tsc --noEmit` passes with no new errors

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)