### PR TITLE
fix(ux): add colorScheme and themeColor to root layout viewport

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Space_Grotesk, IBM_Plex_Mono } from "next/font/google";
 import { Header } from "@/components/shell/Header";
 import { Footer } from "@/components/shell/Footer";
@@ -26,6 +26,14 @@ const ibmPlexMono = IBM_Plex_Mono({
   weight: ["400", "500", "600"],
   display: "swap",
 });
+
+export const viewport: Viewport = {
+  colorScheme: "dark",
+  themeColor: [
+    { media: "(prefers-color-scheme: dark)", color: "#0a0a0a" },
+    { media: "(prefers-color-scheme: light)", color: "#ffffff" },
+  ],
+};
 
 export const metadata: Metadata = {
   metadataBase: new URL(siteConfig.url),


### PR DESCRIPTION
## Summary

- Adds `export const viewport: Viewport` to `src/app/layout.tsx` with `colorScheme: "dark"` and responsive `themeColor` values
- Uses the Next.js App Router `Viewport` type (imported from `"next"`) rather than the deprecated `metadata` fields, eliminating build warnings
- Dark background color (`#0a0a0a`) sourced from `--color-bg` in `globals.css`; light fallback is `#ffffff`
- No conflict with PR #118's Twitter card fields or font preconnect — viewport is a separate named export

## Test plan

- [x] `tsc --noEmit` passes with zero errors
- [x] `next build` produces no `Unsupported metadata colorScheme/themeColor` warnings
- [x] All 37 unit tests pass
- [x] ESLint passes (0 errors, 2 pre-existing warnings in unrelated components)

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)