### PR TITLE
seo: consolidated metadata and structured data improvements

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,9 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+    // Exclude agent worktrees and symlinked external directories:
+    ".claude/worktrees/**",
+    "~Projects/**",
   ]),
 ]);
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -11,6 +11,7 @@ const contentSecurityPolicy = [
 ].join("; ");
 
 const nextConfig: NextConfig = {
+  trailingSlash: false,
   async headers() {
     return [
       {

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -12,7 +12,19 @@ import {
 export const metadata: Metadata = {
   title: "About",
   description: aboutContent.intro.slice(0, 155),
-  alternates: { canonical: "/about" },
+  openGraph: {
+    title: `About | ${siteConfig.name}`,
+    description: aboutContent.intro.slice(0, 155),
+    url: `${siteConfig.url}/about`,
+    siteName: siteConfig.name,
+    type: "profile",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: `About | ${siteConfig.name}`,
+    description: aboutContent.intro.slice(0, 155),
+  },
+  alternates: { canonical: `${siteConfig.url}/about` },
 };
 
 export default function About() {

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -6,6 +6,7 @@ import {
   experienceEntries,
   lookingFor,
   skillCategories,
+  heroContent,
 } from "@/content/site";
 
 export const metadata: Metadata = {
@@ -20,7 +21,13 @@ export default function About() {
     "@type": "Person",
     name: siteConfig.name,
     url: siteConfig.url,
-    jobTitle: "Software Engineer",
+    description: heroContent.subhead,
+    jobTitle: experienceEntries[0].role,
+    worksFor: {
+      "@type": "Organization",
+      name: experienceEntries[0].company,
+    },
+    knowsAbout: skillCategories.flatMap((cat) => cat.skills),
     sameAs: siteConfig.socialLinks
       .filter((l) => l.platform !== "email")
       .map((l) => l.url),

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,7 +1,10 @@
 import { ImageResponse } from 'next/og'
+import { siteConfig } from '@/content/site'
 
 export const size = { width: 1200, height: 630 }
 export const contentType = 'image/png'
+
+const domain = new URL(siteConfig.url).hostname
 
 export default function Image() {
   return new ImageResponse(
@@ -78,7 +81,7 @@ export default function Image() {
                 letterSpacing: '-1px',
               }}
             >
-              Fabrizio Corrales
+              {siteConfig.name}
             </span>
           </div>
 
@@ -96,7 +99,7 @@ export default function Image() {
                 lineHeight: 1,
               }}
             >
-              Software Engineer
+              {siteConfig.tagline}
             </span>
           </div>
 
@@ -115,7 +118,7 @@ export default function Image() {
                 letterSpacing: '0.5px',
               }}
             >
-              Backend-focused · Distributed Systems · Developer Tooling
+              {siteConfig.subtitle}
             </span>
           </div>
         </div>
@@ -137,7 +140,7 @@ export default function Image() {
               letterSpacing: '1px',
             }}
           >
-            slen.win
+            {domain}
           </span>
         </div>
       </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -46,7 +46,7 @@ function GitHubCommitPulseSkeleton() {
 
 export default function Home() {
 
-  const jsonLd = {
+  const personJsonLd = {
     "@context": "https://schema.org",
     "@type": "Person",
     name: siteConfig.name,
@@ -57,11 +57,28 @@ export default function Home() {
       .map((l) => l.url),
   };
 
+  const webSiteJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    name: siteConfig.title,
+    url: siteConfig.url,
+    description: siteConfig.description,
+    author: {
+      "@type": "Person",
+      name: siteConfig.name,
+      url: siteConfig.url,
+    },
+  };
+
   return (
     <>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(personJsonLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(webSiteJsonLd) }}
       />
 
       <section style={{ paddingTop: "var(--space-16)", marginBottom: "var(--space-8)" }}>

--- a/src/app/work/[slug]/page.tsx
+++ b/src/app/work/[slug]/page.tsx
@@ -46,15 +46,21 @@ export default async function CaseStudyPage({
 
   const { previous, next } = getAdjacentCaseStudies(cs.slug);
 
+  // Parse a year from the period string (e.g. "Sept 2025 – Present" → "2025")
+  const yearMatch = cs.period.match(/\d{4}/);
+  const datePublished = yearMatch ? `${yearMatch[0]}-01-01` : undefined;
+
   const jsonLd = {
     "@context": "https://schema.org",
-    "@type": "CreativeWork",
-    name: cs.title,
+    "@type": "Article",
+    headline: cs.title,
     description: cs.summary,
     author: {
       "@type": "Person",
       name: siteConfig.name,
+      url: siteConfig.url,
     },
+    ...(datePublished ? { datePublished } : {}),
     url: `${siteConfig.url}/work/${cs.slug}`,
   };
 

--- a/src/app/work/[slug]/page.tsx
+++ b/src/app/work/[slug]/page.tsx
@@ -58,9 +58,20 @@ export default async function CaseStudyPage({
     url: `${siteConfig.url}/work/${cs.slug}`,
   };
 
+  const breadcrumbJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: "Home", item: siteConfig.url },
+      { "@type": "ListItem", position: 2, name: "Work", item: `${siteConfig.url}/work` },
+      { "@type": "ListItem", position: 3, name: cs.title, item: `${siteConfig.url}/work/${cs.slug}` },
+    ],
+  };
+
   return (
     <article className="container" data-testid="case-study-page">
       <script type="application/ld+json">{JSON.stringify(jsonLd)}</script>
+      <script type="application/ld+json">{JSON.stringify(breadcrumbJsonLd)}</script>
       <nav
         data-testid="case-study-breadcrumbs"
         aria-label="Breadcrumb"

--- a/src/app/work/page.tsx
+++ b/src/app/work/page.tsx
@@ -1,12 +1,27 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { caseStudies } from "@/content/case-studies";
+import { siteConfig } from "@/content/site";
+
+const WORK_DESCRIPTION =
+  "Selected projects spanning product engineering, systems automation, and enterprise platform work.";
 
 export const metadata: Metadata = {
   title: "Work",
-  description:
-    "Selected projects spanning product engineering, systems automation, and enterprise platform work.",
-  alternates: { canonical: "/work" },
+  description: WORK_DESCRIPTION,
+  openGraph: {
+    title: `Work | ${siteConfig.name}`,
+    description: WORK_DESCRIPTION,
+    url: `${siteConfig.url}/work`,
+    siteName: siteConfig.name,
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: `Work | ${siteConfig.name}`,
+    description: WORK_DESCRIPTION,
+  },
+  alternates: { canonical: `${siteConfig.url}/work` },
 };
 
 export default function WorkIndex() {
@@ -22,8 +37,7 @@ export default function WorkIndex() {
           maxWidth: "40rem",
         }}
       >
-        Selected projects spanning product engineering, systems automation, and
-        enterprise platform work.
+        {WORK_DESCRIPTION}
       </p>
 
       <div

--- a/src/content/site.ts
+++ b/src/content/site.ts
@@ -3,6 +3,8 @@ import type { SiteConfig, ExperienceEntry } from "@/lib/content-schema";
 export const siteConfig: SiteConfig = {
   name: "Fabrizio Corrales",
   title: "Slen Portfolio",
+  tagline: "Software Engineer",
+  subtitle: "Backend-focused \u00b7 Distributed Systems \u00b7 Developer Tooling",
   description:
     "Portfolio of Fabrizio Corrales. Backend-focused software engineer building scalable distributed systems, developer tooling, and platform capabilities.",
   url: "https://slen.win",

--- a/src/lib/content-schema.ts
+++ b/src/lib/content-schema.ts
@@ -9,6 +9,8 @@ export const socialLinkSchema = z.object({
 export const siteConfigSchema = z.object({
   name: z.string().min(1),
   title: z.string().min(1),
+  tagline: z.string().min(1),
+  subtitle: z.string().min(1),
   description: z.string().min(10),
   url: z.url(),
   email: z.email(),


### PR DESCRIPTION
## Summary

Consolidates six SEO and metadata fixes from individual feature branches into a single PR:

- **trailingSlash config** -- Set `trailingSlash: false` in `next.config.ts` to enforce canonical URL form and prevent duplicate content penalties
- **OG image siteConfig refs** -- Replace hardcoded name, tagline, subtitle, and domain in the OpenGraph image generator with `siteConfig` references so the OG preview stays in sync with the single source of truth
- **BreadcrumbList JSON-LD** -- Add `BreadcrumbList` structured data (`Home > Work > title`) to case study pages so Google can display breadcrumb trails in search snippets
- **WebSite + Person JSON-LD** -- Add `WebSite` structured data to the home page and enrich the about page `Person` schema with `description`, `worksFor`, and `knowsAbout` fields
- **Article JSON-LD** -- Upgrade case study JSON-LD from `CreativeWork` to `Article` schema with `headline`, `author.url`, and `datePublished` for rich Article results
- **openGraph metadata** -- Add `openGraph` and `twitter` metadata blocks to `/about` and `/work` pages so social shares display page-specific titles and descriptions

Also includes an ESLint ignore fix to prevent the linter from scanning `.claude/worktrees` and `~Projects` directories.

Closes #200, Closes #196, Closes #197, Closes #186, Closes #180, Closes #173

## Test plan

- [x] `npx tsc --noEmit` passes with zero errors
- [x] `pnpm build` produces a successful production build
- [x] All 37 unit tests pass
- [x] ESLint reports 0 errors (2 pre-existing warnings)
- [ ] Verify trailing slash behavior: URLs without trailing slash should be canonical
- [ ] Validate JSON-LD output on home, about, and case study pages using Google Rich Results Test
- [ ] Confirm OG tags render correctly via social share preview tools (e.g., opengraph.xyz)

🤖 Generated with [Claude Code](https://claude.com/claude-code)