### PR TITLE
fix: security hardening and type-safety bug fixes

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export function middleware(request: NextRequest) {
+  const nonce = Buffer.from(crypto.randomUUID()).toString("base64");
+
+  const csp = [
+    `default-src 'self'`,
+    `script-src 'self' 'nonce-${nonce}' 'strict-dynamic' https://va.vercel-scripts.com https://vitals.vercel-analytics.com`,
+    `connect-src 'self' https://va.vercel-scripts.com https://vitals.vercel-analytics.com`,
+    `style-src 'self' 'unsafe-inline' https://fonts.googleapis.com`,
+    `font-src 'self' https://fonts.gstatic.com`,
+    `media-src 'self' data: blob:`,
+    `img-src 'self' data: blob:`,
+  ].join("; ");
+
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set("x-nonce", nonce);
+  requestHeaders.set("Content-Security-Policy", csp);
+
+  const response = NextResponse.next({ request: { headers: requestHeaders } });
+  response.headers.set("Content-Security-Policy", csp);
+
+  return response;
+}
+
+export const config = {
+  matcher: [
+    /*
+     * Match all request paths except:
+     * - _next/static (static files)
+     * - _next/image (image optimization files)
+     * - favicon.ico, favicon.svg, sitemap.xml, robots.txt (metadata files)
+     */
+    {
+      source:
+        "/((?!_next/static|_next/image|favicon\\.ico|favicon\\.svg|sitemap\\.xml|robots\\.txt).*)",
+      missing: [
+        { type: "header", key: "next-router-prefetch" },
+        { type: "header", key: "purpose", value: "prefetch" },
+      ],
+    },
+  ],
+};

--- a/next.config.ts
+++ b/next.config.ts
@@ -34,7 +34,8 @@ const nextConfig: NextConfig = {
           },
           {
             key: "Permissions-Policy",
-            value: "camera=(), microphone=(), geolocation=()",
+            value:
+              "camera=(), microphone=(), geolocation=(), payment=(), usb=(), interest-cohort=(), accelerometer=(), gyroscope=(), magnetometer=(), display-capture=(), fullscreen=(self), picture-in-picture=()",
           },
         ],
       },

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,25 +1,12 @@
 import type { NextConfig } from "next";
 
-const contentSecurityPolicy = [
-  "default-src 'self'",
-  "script-src 'self' 'unsafe-inline' https://va.vercel-scripts.com https://vitals.vercel-analytics.com",
-  "connect-src 'self' https://va.vercel-scripts.com https://vitals.vercel-analytics.com",
-  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
-  "font-src 'self' https://fonts.gstatic.com",
-  "media-src 'self' data: blob:",
-  "img-src 'self' data: blob:",
-].join("; ");
-
 const nextConfig: NextConfig = {
   async headers() {
     return [
       {
         source: "/:path*",
         headers: [
-          {
-            key: "Content-Security-Policy",
-            value: contentSecurityPolicy,
-          },
+          // CSP is set per-request in middleware.ts (nonce-based)
           {
             key: "X-Frame-Options",
             value: "DENY",

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { headers } from "next/headers";
 import Image from "next/image";
 import {
   siteConfig,
@@ -14,7 +15,9 @@ export const metadata: Metadata = {
   alternates: { canonical: "/about" },
 };
 
-export default function About() {
+export default async function About() {
+  const nonce = (await headers()).get("x-nonce") ?? undefined;
+
   const jsonLd = {
     "@context": "https://schema.org",
     "@type": "Person",
@@ -29,6 +32,7 @@ export default function About() {
     <div className="container">
       <script
         type="application/ld+json"
+        nonce={nonce}
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
       <div

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from "react";
+import { headers } from "next/headers";
 import Image from "next/image";
 import Link from "next/link";
 import {
@@ -44,7 +45,8 @@ function GitHubCommitPulseSkeleton() {
   );
 }
 
-export default function Home() {
+export default async function Home() {
+  const nonce = (await headers()).get("x-nonce") ?? undefined;
 
   const jsonLd = {
     "@context": "https://schema.org",
@@ -61,6 +63,7 @@ export default function Home() {
     <>
       <script
         type="application/ld+json"
+        nonce={nonce}
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
 

--- a/src/app/work/[slug]/page.tsx
+++ b/src/app/work/[slug]/page.tsx
@@ -357,42 +357,44 @@ export default async function CaseStudyPage({
       </section>
 
       {/* Proof Links */}
-      <section
-        data-testid="case-study-proof-links"
-        style={{ marginBottom: "var(--space-12)" }}
-      >
-        <h2 style={{ marginBottom: "var(--space-4)" }}>Proof</h2>
-        <div
-          style={{
-            display: "flex",
-            flexWrap: "wrap",
-            gap: "var(--space-3)",
-          }}
+      {cs.proofLinks && cs.proofLinks.length > 0 && (
+        <section
+          data-testid="case-study-proof-links"
+          style={{ marginBottom: "var(--space-12)" }}
         >
-          {cs.proofLinks.map((link) => (
-            <a
-              key={link.url}
-              href={link.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              style={{
-                display: "inline-flex",
-                padding: "var(--space-2) var(--space-4)",
-                border: "1px solid var(--color-border)",
-                borderRadius: "var(--radius-md)",
-                fontFamily: "var(--font-mono)",
-                fontSize: "var(--text-sm)",
-                color: "var(--color-text-secondary)",
-                textDecoration: "none",
-                transition:
-                  "border-color var(--duration-fast) var(--easing)",
-              }}
-            >
-              {link.label} &rarr;
-            </a>
-          ))}
-        </div>
-      </section>
+          <h2 style={{ marginBottom: "var(--space-4)" }}>Proof</h2>
+          <div
+            style={{
+              display: "flex",
+              flexWrap: "wrap",
+              gap: "var(--space-3)",
+            }}
+          >
+            {cs.proofLinks.map((link) => (
+              <a
+                key={link.url}
+                href={link.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{
+                  display: "inline-flex",
+                  padding: "var(--space-2) var(--space-4)",
+                  border: "1px solid var(--color-border)",
+                  borderRadius: "var(--radius-md)",
+                  fontFamily: "var(--font-mono)",
+                  fontSize: "var(--text-sm)",
+                  color: "var(--color-text-secondary)",
+                  textDecoration: "none",
+                  transition:
+                    "border-color var(--duration-fast) var(--easing)",
+                }}
+              >
+                {link.label} &rarr;
+              </a>
+            ))}
+          </div>
+        </section>
+      )}
 
       {/* Reflection */}
       <section style={{ marginBottom: "var(--space-12)" }}>

--- a/src/app/work/[slug]/page.tsx
+++ b/src/app/work/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { headers } from "next/headers";
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import {
@@ -37,6 +38,7 @@ export default async function CaseStudyPage({
 }: {
   params: Promise<{ slug: string }>;
 }) {
+  const nonce = (await headers()).get("x-nonce") ?? undefined;
   const { slug } = await params;
   const cs = getCaseStudyBySlug(slug);
 
@@ -60,7 +62,7 @@ export default async function CaseStudyPage({
 
   return (
     <article className="container" data-testid="case-study-page">
-      <script type="application/ld+json">{JSON.stringify(jsonLd)}</script>
+      <script type="application/ld+json" nonce={nonce}>{JSON.stringify(jsonLd)}</script>
       <nav
         data-testid="case-study-breadcrumbs"
         aria-label="Breadcrumb"

--- a/src/components/TypingTest.tsx
+++ b/src/components/TypingTest.tsx
@@ -196,7 +196,7 @@ export function TypingTest() {
   const [personalBest, setPersonalBest] = useState(0);
   const [isNewRecord, setIsNewRecord] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
-  const timerRef = useRef<ReturnType<typeof setInterval>>(undefined);
+  const timerRef = useRef<ReturnType<typeof setInterval> | undefined>(undefined);
   const containerRef = useRef<HTMLDivElement>(null);
 
   const accuracy = totalChars > 0 ? Math.round((correctChars / totalChars) * 100) : 100;

--- a/src/content/case-studies.ts
+++ b/src/content/case-studies.ts
@@ -342,7 +342,7 @@ export const caseStudies: CaseStudy[] = [
     },
     featured: true,
   },
-];
+] satisfies CaseStudy[];
 
 export function getCaseStudyBySlug(slug: string): CaseStudy | undefined {
   return caseStudies.find((cs) => cs.slug === slug);

--- a/src/lib/content-schema.ts
+++ b/src/lib/content-schema.ts
@@ -77,7 +77,7 @@ export const caseStudySchema = z.object({
       label: z.string().min(1),
       url: z.url(),
     })
-  ).min(1),
+  ).optional().default([]),
   disclosure: disclosureMatrixSchema,
   disclaimer: z.string().optional(),
   featured: z.boolean().default(false),

--- a/src/test/content-schema-invalid.test.ts
+++ b/src/test/content-schema-invalid.test.ts
@@ -26,7 +26,7 @@ describe("Schema rejects invalid data", () => {
     expect(result.success).toBe(false);
   });
 
-  it("rejects case study missing proofLinks", () => {
+  it("accepts case study with empty proofLinks", () => {
     const result = caseStudySchema.safeParse({
       slug: "form-factor",
       title: "Test",
@@ -48,7 +48,7 @@ describe("Schema rejects invalid data", () => {
         proofLinks: [],
       },
     });
-    expect(result.success).toBe(false);
+    expect(result.success).toBe(true);
   });
 
   it("rejects case study missing outcomes", () => {

--- a/src/test/smoke.test.tsx
+++ b/src/test/smoke.test.tsx
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 
+vi.mock("next/headers", () => ({
+  headers: vi.fn().mockResolvedValue(new Headers({ "x-nonce": "test-nonce" })),
+}));
+
 vi.mock("@/components/home/GitHubCommitPulse", () => ({
   GitHubCommitPulse: () => <div data-testid="github-commit-pulse" />,
 }));
@@ -12,8 +16,9 @@ vi.mock("@/components/home/InteractiveTerminal", () => ({
 import Home from "@/app/page";
 
 describe("Home page", () => {
-  it("renders the heading", () => {
-    render(<Home />);
+  it("renders the heading", async () => {
+    const jsx = await Home();
+    render(jsx);
     expect(screen.getByRole("heading", { level: 1 })).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

This PR combines five targeted fixes addressing type-safety bugs and security hardening:

### Type-Safety Fixes
- **TypingTest timer ref** (`#140`): Include `undefined` in the `useRef<NodeJS.Timeout>` type to match the actual runtime behaviour when the ref hasn't been assigned yet.
- **Case-studies `satisfies` operator** (`#139`): Add the `satisfies CaseStudy[]` operator to the case-studies array for compile-time validation without widening the type.
- **Empty proof links guard** (`#131`): Guard the proof-links section in `work/[slug]/page.tsx` against empty or undefined `proofLinks`, and update `content-schema.ts` accordingly.

### Security Hardening
- **Permissions-Policy header** (`#175`): Expand the `Permissions-Policy` response header in `next.config.ts` to explicitly restrict high-risk browser APIs (camera, microphone, geolocation, etc.).
- **Nonce-based CSP via middleware** (`#174`): Replace the static `unsafe-inline` CSP directive with per-request nonce-based Content Security Policy using Next.js middleware. Adds `middleware.ts` with cryptographic nonce generation and `strict-dynamic`, and threads the nonce into JSON-LD script tags across page components.

## Issues

Closes #140
Closes #139
Closes #131
Closes #175
Closes #174

## Test plan

- [x] `npx tsc --noEmit` passes with no errors
- [x] ESLint passes (pre-existing warnings only)
- [x] All 37 unit tests pass
- [x] Production build succeeds with middleware proxy route
- [ ] Verify nonce appears in CSP header and inline script tags in deployed preview
- [ ] Verify Permissions-Policy header includes all restricted APIs
- [ ] Verify case study pages render correctly with and without proof links

🤖 Generated with [Claude Code](https://claude.com/claude-code)