### PR TITLE
fix(resume): bypass boot overlay on resume page

### DIFF
--- a/src/components/shell/BootSequence.tsx
+++ b/src/components/shell/BootSequence.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { usePathname } from "next/navigation";
 import { useSessionFlag } from "@/hooks/useSessionFlag";
 import { usePrefersReducedMotion } from "@/hooks/usePrefersReducedMotion";
 import { bootLines, motionConfig } from "@/content/system";
@@ -9,12 +10,14 @@ const FADE_DURATION_MS = 500;
 const SKIP_BOOT_IN_DEVELOPMENT = process.env.NODE_ENV === "development";
 
 export function BootSequence() {
+  const pathname = usePathname();
   const [seen, setFlag] = useSessionFlag("boot-seen");
   const prefersReducedMotion = usePrefersReducedMotion();
   const [visibleCount, setVisibleCount] = useState(0);
   const [fadingOut, setFadingOut] = useState(false);
   const [unmounted, setUnmounted] = useState(false);
   const overlayRef = useRef<HTMLDivElement>(null);
+  const skipForResumeRoute = pathname === "/resume";
 
   const dismiss = useCallback(() => {
     setFadingOut(true);
@@ -29,7 +32,7 @@ export function BootSequence() {
   }, [prefersReducedMotion, setFlag]);
 
   useEffect(() => {
-    if (seen || prefersReducedMotion || unmounted) {
+    if (seen || prefersReducedMotion || skipForResumeRoute || unmounted) {
       return;
     }
 
@@ -44,10 +47,10 @@ export function BootSequence() {
     return () => {
       window.removeEventListener("keydown", handleKeyDown);
     };
-  }, [dismiss, prefersReducedMotion, seen, unmounted]);
+  }, [dismiss, prefersReducedMotion, seen, skipForResumeRoute, unmounted]);
 
   useEffect(() => {
-    if (seen || prefersReducedMotion) return;
+    if (seen || prefersReducedMotion || skipForResumeRoute) return;
 
     const timers: ReturnType<typeof setTimeout>[] = [];
 
@@ -73,9 +76,17 @@ export function BootSequence() {
     );
 
     return () => timers.forEach(clearTimeout);
-  }, [seen, prefersReducedMotion, setFlag]);
+  }, [seen, prefersReducedMotion, setFlag, skipForResumeRoute]);
 
-  if (SKIP_BOOT_IN_DEVELOPMENT || seen || prefersReducedMotion || unmounted) return null;
+  if (
+    SKIP_BOOT_IN_DEVELOPMENT ||
+    seen ||
+    prefersReducedMotion ||
+    skipForResumeRoute ||
+    unmounted
+  ) {
+    return null;
+  }
 
   return (
     <section

--- a/tests/e2e/about.spec.ts
+++ b/tests/e2e/about.spec.ts
@@ -42,6 +42,14 @@ test.describe("About page", () => {
     await expect(page.locator('iframe[title="Fabrizio Corrales resume"]')).toBeVisible();
   });
 
+  test("mobile resume route skips boot overlay", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto("/resume", { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByTestId("boot-sequence")).toHaveCount(0);
+    await expect(page.locator('iframe[title="Fabrizio Corrales resume"]')).toBeVisible();
+  });
+
   test("about page has no form elements", async ({ page }) => {
     await page.goto("/about");
     const forms = page.locator("form");

--- a/tests/e2e/about.spec.ts
+++ b/tests/e2e/about.spec.ts
@@ -37,6 +37,7 @@ test.describe("About page", () => {
     page,
   }) => {
     await page.goto("/resume");
+    await expect(page.getByTestId("boot-sequence")).toHaveCount(0);
     await expect(page).toHaveTitle(/Resume/);
     await expect(page.locator('iframe[title="Fabrizio Corrales resume"]')).toBeVisible();
   });


### PR DESCRIPTION
## Summary
- hard-bypass the global boot overlay on /resume so the PDF viewer renders immediately
- keep the bypass route-scoped so visiting /resume does not mark the normal portfolio boot sequence as seen
- add E2E coverage for both desktop and mobile /resume, including the reported 390px mobile black-screen case

## Validation
- pnpm lint
- pnpm typecheck
- pnpm test -- --run src/test/site-shell.test.tsx src/test/about-page.test.tsx
- pnpm build
- PLAYWRIGHT_PORT=3106 PLAYWRIGHT_WORKERS=2 pnpm test:e2e -- tests/e2e/about.spec.ts
- PLAYWRIGHT_PORT=3107 PLAYWRIGHT_WORKERS=2 pnpm test:e2e -- tests/e2e/about.spec.ts (5 passed, includes mobile resume route)
- pre-push hook passed lint/typecheck/unit/build

## Notes
- This is intentionally a separate hotfix PR from #211.
- No .omo workspace files included.